### PR TITLE
feat: control hangar HVAC (Durastar/Midea mini-split) via WiFi dongle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,18 @@
 # Option B: set coordinates directly
 # LATITUDE=45.5051
 # LONGITUDE=-122.6750
+
+# ---------------------------------------------------------------------------
+# Hangar HVAC (Durastar mini-split via Midea WiFi dongle)
+# ---------------------------------------------------------------------------
+# These four values are written automatically by `python3 setup_hvac.py`
+# after you pair the dongle via the NetHome Plus app. Do not edit by hand.
+# HVAC_DONGLE_IP=192.168.1.50
+# HVAC_DEVICE_ID=123456789012345
+# HVAC_TOKEN=...
+# HVAC_KEY=...
+
+# ---------------------------------------------------------------------------
+# Monthly email summaries (optional)
+# ---------------------------------------------------------------------------
+# NOTIFY_EMAIL=you@example.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,17 @@ Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set
 - **Freeze Prevention is a SOFTWARE PRESET, not a real anti-freeze flag.** `_resolve_freeze()` returns `(power=True, mode=HEAT, target_f=60, fan=LOW)` — Midea's heat-mode minimum. msmart-ng does not expose Midea's actual "8°C heating" feature byte over the dongle (it's IR-only on most units). If a true anti-freeze API later surfaces, replace `_resolve_freeze()` and leave the preset name unchanged.
 - **`state_for_log()`** returns `None` (not 0) when not configured / unreachable, so the `readings.ac_state` column stays NULL rather than misreporting "off". Aggregations treat `None` as "no data, don't render".
 
+## msmart-ng API surface (verified 2025.12.0)
+The wrappers were verified against msmart-ng 2025.12.0. If you upgrade, watch these specific symbols — past versions have moved them, and a future bump may again:
+- `from msmart.device import AirConditioner as AC` — constructor is positional `AC(ip, device_id, port)`. `await dev.authenticate(token, key)` (async) replaces older property-assignment patterns. Then `await dev.refresh()` and `await dev.apply()`.
+- Enums: `AC.OperationalMode.{AUTO, COOL, DRY, HEAT, FAN_ONLY, SMART_DRY}`, `AC.FanSpeed.{AUTO, MAX, HIGH, MEDIUM, LOW, SILENT}`. We map our 4 fan tokens to AUTO/LOW/MEDIUM/HIGH.
+- `from msmart.discover import Discover`. `Discover.discover(*, account=…, password=…, auto_connect=True)` does both LAN UDP discovery AND the cloud handshake in one call — returned `Device` objects already have `.token` / `.key` populated. **Do not call `cloud.get_token()` separately.**
+- `from msmart.cloud import NetHomePlusCloud, SmartHomeCloud, BaseCloud`. The plain `Cloud` class no longer exists. We don't instantiate any of these directly — `Discover.discover()` does it for us.
+- A drift sentinel: try `python3 -c "from msmart.cloud import NetHomePlusCloud"` after a version bump. If it fails, the API moved again and `setup_hvac.py` needs another patch.
+
 ## HVAC pairing (`setup_hvac.py`)
-- Use the **NetHome Plus** app to pair, NOT SmartHome. The SmartHome `get_token` cloud endpoint is currently broken (msmart-ng issue #201). The script enforces `account="NetHomePlus"` when it calls `Cloud(...)`.
+- Use the **NetHome Plus** app to pair, NOT SmartHome / MSmartHome. The SmartHome `get_token` cloud endpoint is currently broken (msmart-ng issue #201). If the user is on a SmartHome account they must re-register through NetHome Plus first.
+- The script is one round-trip: prompt creds → `Discover.discover(account=, password=, auto_connect=True)` → returned device already has token+key → write `.env` → verify.
 - One-time cloud roundtrip during pairing only; all subsequent control is local on TCP/6444. After pairing, the dongle's outbound internet can be blocked at the firewall without losing functionality.
 - The script preserves other `.env` keys (only replaces the four `HVAC_*` lines).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project context for Claude
 
 ## What this is
-Raspberry Pi airplane hangar heater controller. The web UI lets the user remotely toggle a GPIO-controlled relay (the heater), view a temperature/heater-state chart (7d/30d/monthly), and schedule future on/off actions. The DS18B20 probe logs hangar temp; outdoor ambient comes from Open-Meteo via lat/lon. The Pi Zero W is LTE-connected and physically located at the hangar.
+Raspberry Pi airplane hangar controller. The web UI controls three independent devices in the hangar (engine-block heater, exhaust fan, climate HVAC), shows a temperature/state chart (7d/30d/monthly), and schedules future actions. The DS18B20 probe logs hangar temp; outdoor ambient comes from Open-Meteo via lat/lon. The Pi Zero W is at the hangar; primarily on hangar WiFi with LTE as backup.
 
 ## Runtime architecture
 - **No standalone Python service.** The app runs as Apache mod_wsgi (`switch.py`) + root cron jobs. No daemon, no Docker, no systemd app service.
@@ -9,14 +9,37 @@ Raspberry Pi airplane hangar heater controller. The web UI lets the user remotel
 - `config.py` — shared constants, DB helpers, GPIO, temp probe, ambient fetch
 - `aggregate.py` — aggregation logic for chart data and stats
 - `log_temp.py` — cron job: logs readings every minute, flushes weekly, rollup monthly
+- `hvac.py` — Hangar HVAC (Durastar/Midea mini-split) control via WiFi dongle on LAN, msmart-ng wrapper
+- `setup_hvac.py` — one-time pairing helper: discovers the dongle, fetches local token+key, writes HVAC_* keys to .env
 - `templates/index.html` — Jinja2 template
 - `heater-flush.service` — systemd unit, flushes RAM DB to disk on commanded shutdown/reboot
 
+## Three independent controlled devices
+**Don't conflate these — they are physically and electrically separate systems.**
+1. **Engine-block heater** (`config.GPIO_PIN`=17) — relay on the airplane oil-pan heater. The original purpose of this project. Toggled by the web UI's "Heater" card and `?state=` query param.
+2. **Exhaust fan** (`config.FAN_GPIO_PIN`=27) — relay on a hangar exhaust fan with auto/on/off mode.
+3. **Hangar HVAC** — Durastar DRAW33F2A mini-split (Midea OEM) reached over the LAN via the Midea WiFi dongle (US-OSK105) using `msmart-ng` on TCP/6444. Controlled from the "Hangar HVAC" card. Has its own scheduling path through the same scheduler. All HVAC code lives in `hvac.py`; `config.py` and the heater code never touch it.
+
 ## Storage
+**Hot-path writes MUST go to `/run` (tmpfs / RAM), not `/var/lib/heater` (SD card).** SD cards on a Pi Zero W have a limited write-cycle budget; this app runs every minute for years. Any new feature that writes more often than ~once a week belongs in `/run`. The accepted tradeoff: anything in `/run` is lost on unplanned power loss — for this hangar that's fine because the disk DB has data up to the last weekly flush, and the `heater-flush.service` systemd unit catches commanded reboots/shutdowns.
+
+Files:
 - `/run/heater.db` — RAM (tmpfs). **Only holds `readings` table.** Written every minute by cron.
-- `/var/lib/heater/heater.db` — Disk. Holds `readings` + `schedules` + `monthly_cache`. Flushed weekly.
-- `/run/heater-ambient.tmp` — Ambient temp cache, 15-min TTL, ~50 bytes.
+- `/run/heater-ambient.tmp` — Ambient temp cache, 15-min TTL, ~50 bytes. Written ~96×/day.
+- `/run/heater-hvac.json` — Cached HVAC dongle state (reported + commanded views), 30s TTL, ~400 bytes. Written every minute by `log_temp.py` (via `hvac.state_for_log()`) and on every HVAC apply.
+- `/var/lib/heater/heater.db` — Disk (SD card). Holds `readings` + `schedules` + `monthly_cache`. Written **only weekly** (`log_temp.py flush`) and **monthly** (`log_temp.py rollup`), plus when the user adds/cancels a schedule (rare).
 - The web UI ATTACHes both DBs and reads from both — no data gap between flushes.
+
+When adding a new persistent thing, ask: how often is it written? If more than weekly → `/run`. If user-action-driven and rare → SD card is fine.
+
+## Schedule schema (extended for HVAC)
+The `schedules` table has two columns added on top of the original heater schema:
+- `device TEXT DEFAULT 'heater'` — `'heater'` or `'hvac'`
+- `params TEXT DEFAULT ''` — JSON for HVAC schedules: `{power, mode, target_f, fan_speed}` or `{mode: "freeze"}`
+Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set"` and read everything from `params`. `log_temp.py do_log()` dispatches by device.
+
+## Readings columns added for HVAC
+`readings.ac_state INTEGER` — 0=off, 1=heat, 2=cool, 3=fan, 4=dry, 5=auto. Logged every minute by cron via `hvac.state_for_log()`. `aggregate.compute_bucketed` collapses this to a binary "any non-off" band rendered in purple on the chart.
 
 ## Schedules
 - Stored in **disk DB only** — survive reboots with no extra effort.
@@ -28,3 +51,39 @@ Raspberry Pi airplane hangar heater controller. The web UI lets the user remotel
 - METAR/TAF fetched server-side (`?metar=1`, `?taf=1`) to avoid CORS issues with aviationweather.gov.
 - `LOCATION` in `.env` can be an ICAO code (e.g. `KLMO`); lat/lon resolved via OurAirports CSV geocoding on first run.
 - mod_wsgi daemon mode auto-reloads when `switch.py` changes — `git pull` is sufficient, no Apache restart needed.
+- All schema additions use `ALTER TABLE ... ADD COLUMN` wrapped in try/except in `get_db()` / `get_ram_db()`. Don't introduce a separate migration system.
+
+## HVAC module specifics (`hvac.py`)
+- **Source of truth for the hangar climate.** All Durastar/Midea code lives here; nothing else imports `msmart`.
+- **Lazy import:** `import msmart` happens only inside helper functions, so the WSGI app and cron jobs boot fine on a Pi that hasn't run `pip install msmart-ng` yet. `is_configured()` checks `.env` keys without ever touching the network.
+- **Async→sync bridge:** `asyncio.run(coro)` wraps every call. mod_wsgi handlers stay sync; the dongle is on the LAN so RTT is sub-second.
+- **Cache file** `/run/heater-hvac.json`:
+  ```json
+  {"reported": {power, mode, target_c, target_f, fan_speed, indoor_c, indoor_f, epoch},
+   "commanded": {…same fields…} | null}
+  ```
+  TTL is `hvac.CACHE_TTL_SECS = 30`. `get_state()` returns `{reported, commanded, stale, age_secs, diverged}`. On dongle error, returns the stale cached view with `stale=True` instead of raising.
+- **Two-way visibility:** `set_state()` writes both `reported` (post-apply) and `commanded` (what we asked for). UI surfaces commanded only when `_diverged()` returns True (catches drift if someone uses the physical IR remote — common in this hangar).
+- **Stable mode/fan tokens** (used in `.env`, schedule `params` JSON, `?hvac_*=` query strings, and chart logic): `MODE_AUTO/COOL/DRY/HEAT/FAN/FREEZE` and `FAN_AUTO/LOW/MED/HIGH`. Don't add or rename without checking all four call sites.
+- **Freeze Prevention is a SOFTWARE PRESET, not a real anti-freeze flag.** `_resolve_freeze()` returns `(power=True, mode=HEAT, target_f=60, fan=LOW)` — Midea's heat-mode minimum. msmart-ng does not expose Midea's actual "8°C heating" feature byte over the dongle (it's IR-only on most units). If a true anti-freeze API later surfaces, replace `_resolve_freeze()` and leave the preset name unchanged.
+- **`state_for_log()`** returns `None` (not 0) when not configured / unreachable, so the `readings.ac_state` column stays NULL rather than misreporting "off". Aggregations treat `None` as "no data, don't render".
+
+## HVAC pairing (`setup_hvac.py`)
+- Use the **NetHome Plus** app to pair, NOT SmartHome. The SmartHome `get_token` cloud endpoint is currently broken (msmart-ng issue #201). The script enforces `account="NetHomePlus"` when it calls `Cloud(...)`.
+- One-time cloud roundtrip during pairing only; all subsequent control is local on TCP/6444. After pairing, the dongle's outbound internet can be blocked at the firewall without losing functionality.
+- The script preserves other `.env` keys (only replaces the four `HVAC_*` lines).
+
+## URL surface
+- Heater: `?state=0|1`
+- Fan: `?fan_state=0|1`, `?fan_mode=auto`
+- HVAC immediate apply: `?hvac_apply=1` plus `&hvac_power=0|1&hvac_mode=…&hvac_target_f=…&hvac_fan_speed=…`. Special case: `&hvac_mode=freeze` triggers the Freeze Prevention preset and ignores the other args.
+- Schedule add: `?sched_dt=YYYY-MM-DDTHH:MM&sched_device=heater|hvac` plus device-specific params (`sched_action` for heater; `sched_hvac_mode/target_f/fan_speed/power` for HVAC).
+- Schedule cancel: `?cancel_id=<created_epoch>`.
+- Chart range: `?range=7d|30d|YYYY-MM`.
+
+## Chart bands and colors
+- Heater (engine-block) — `rgba(220, 53, 69, 0.25)` red
+- HVAC (climate) — `rgba(168, 85, 247, 0.25)` purple
+- Fan — `rgba(13, 110, 253, 0.20)` blue
+- Cold (≤48°F) — `rgba(255, 152, 0, 0.15)` orange box annotation
+- Ambient line — `rgb(34, 197, 94)` green

--- a/README.md
+++ b/README.md
@@ -223,10 +223,12 @@ Midea **US-OSK105** WiFi USB dongle (~$30 on Amazon: ASIN [B0GVSPFK1P](https://w
 
 1. **Plug** the dongle into the USB-shaped port behind the indoor unit's front panel (the snap-off filter cover; no electrical work).
 2. **Pair** it once via the **NetHome Plus** phone app — NOT SmartHome / MSmartHome. Their `get_token` cloud endpoint is currently broken (see [msmart-ng issue #201](https://github.com/mill1000/midea-msmart/issues/201)). If you registered through SmartHome, re-register via NetHome Plus before continuing.
-3. **Install msmart-ng** on the Pi:
+3. **Install msmart-ng** on the Pi (Pi OS Lite ships without pip by default):
    ```bash
-   sudo pip install msmart-ng
+   sudo apt install python3-pip
+   sudo pip install msmart-ng --break-system-packages
    ```
+   The `--break-system-packages` flag is needed on Bookworm and later (PEP 668). For this project's deployment model (system Python under mod_wsgi + root cron) it's the pragmatic choice — a venv would require reconfiguring the WSGI daemon and cron paths.
 4. **Run the setup helper** — it discovers the dongle on the LAN, prompts for your NetHome Plus credentials, fetches the local `token` + `key`, writes the four `HVAC_*` keys to `.env`, and verifies with a refresh:
    ```bash
    sudo python3 /usr/lib/cgi-bin/remote-switch/setup_hvac.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # remote-switch
-Raspberry Pi connected to a mobile/cell network to turn on/off an AC-powered device.
+Raspberry Pi airplane hangar controller. Started as a one-relay remote for the airplane's engine-block oil-pan heater; now also runs an exhaust fan and a Durastar/Midea mini-split HVAC over the LAN — all from a single Pi Zero W on hangar WiFi (with LTE backup).
 
-I use it in an airplane hangar to turn on an airplane oil pan heater, but it would work anywhere there is reception and power to turn on/off any device.
+The web UI shows current state of all three devices, a 7d/30d/monthly temperature chart with colored bands per device, and a one-shot scheduler that can drive any of them.
 
 ## Equipment
 
@@ -11,11 +11,13 @@ Links provided for your convenience, but buy from wherever you prefer.
   * You'll need a microSD card if you don't have one. 4GB+ is enough.
 * [SIM7600 LTE modem HAT for Pi](https://www.waveshare.com/sim7600a-h-4g-hat.htm) also available on [Amazon](https://www.amazon.com/SIM7600A-H-4G-HAT-Communication-Positioning/dp/B082WH85WV/)
   * You'll need a SIM card. The docs say nano but the unit I had uses a mini SIM slot. I used a Google Fi SIM since it only costs data on my existing plan.
-  * Skip this if you already have reliable WiFi.
+  * Skip this if you already have reliable WiFi at the hangar.
 * [Digital Loggers IoT relay](https://dlidirect.com/products/iot-power-relay)
   * Connect `-` to GND on the Pi, and `+` to an unused GPIO pin.
-* (optional) [DS18B20 temperature probe](https://www.adafruit.com/product/381) — displays temperature on the control page
+  * Two of these for the engine-block heater (GPIO 17) and exhaust fan (GPIO 27).
+* (optional) [DS18B20 temperature probe](https://www.adafruit.com/product/381) — displays temperature on the control page and drives fan auto-mode
   * You'll also need a 4.7kΩ resistor between the data and power lines.
+* (optional) Midea **US-OSK105** WiFi USB dongle (~$30 on Amazon as ASIN B0GVSPFK1P) — required only if you want to control a Durastar or other Midea-OEM mini-split. See [Hangar HVAC](#optional-hangar-hvac-durastar-mini-split) below.
 
 ## Setup
 
@@ -198,7 +200,61 @@ Requires [`msmtp`](https://marlam.de/msmtp/) to be installed and configured. The
 
 ## Scheduling
 
-The web UI includes a one-shot scheduler to turn the heater on or off at a future date and time. Schedules are stored in the database and executed by the every-minute cron job — no additional setup needed. Schedules survive reboots.
+The web UI includes a one-shot scheduler that can act on either the engine-block heater (turn on/off) or the hangar HVAC (mode + target temp + fan, including a one-click Freeze Prevention preset). Schedules are stored in the database and executed by the every-minute cron job — no additional setup needed. Schedules survive reboots.
+
+---
+
+## Optional: Hangar HVAC (Durastar mini-split)
+
+The web UI can also control a hangar Durastar/Midea mini-split (and any other Midea-OEM unit — Pioneer, MrCool, Senville, Comfee, etc.) over the LAN via the Midea WiFi dongle. This is independent of the engine-block heater described above — the heater stays on its own GPIO relay; the HVAC is reached over the LAN through the [`msmart-ng`](https://github.com/mill1000/midea-msmart) Python library.
+
+### How it works
+- A small WiFi dongle plugs into a USB-shaped port inside the indoor unit's front panel and bridges Midea's serial protocol to a TCP service on port 6444 of the dongle's LAN IP.
+- After a one-time pairing through Midea's cloud, the Pi extracts a local `token` + `key` and from then on talks to the dongle directly on the LAN — no cloud roundtrip per command, and you can firewall the dongle off the internet.
+- The web UI's HVAC card lets you set power, mode (Heat / Cool / Auto / Dry / Fan), target temperature in °F, and fan speed. A one-click "Freeze Prevention preset" button sends Heat / 60°F / Low fan — useful for "keep the hangar from freezing" scenarios.
+- The scheduler accepts HVAC actions alongside heater actions; same `execute_epoch <= now` cron-driven dispatch.
+- The dongle is polled at most once every 30 seconds (cached in `/run/heater-hvac.json`); page loads never block on the network. If the dongle is unreachable, the UI shows the last-known state with a "stale Xs" badge instead of erroring.
+- HVAC activity is logged into `readings.ac_state` every minute and rendered on the chart as a purple band, so you can see HVAC + heater + fan + ambient temperature on one timeline.
+
+### Hardware
+Midea **US-OSK105** WiFi USB dongle (~$30 on Amazon: ASIN [B0GVSPFK1P](https://www.amazon.com/SmartKit-Adapter-Communication-Wireless-Connectivity/dp/B0GVSPFK1P)). The Durastar-branded `DRWIFIADPT1` is the same hardware behind a contractor-only Ferguson SKU — buy the generic Midea version and skip the wait.
+
+### Setup
+
+1. **Plug** the dongle into the USB-shaped port behind the indoor unit's front panel (the snap-off filter cover; no electrical work).
+2. **Pair** it once via the **NetHome Plus** phone app — NOT SmartHome / MSmartHome. Their `get_token` cloud endpoint is currently broken (see [msmart-ng issue #201](https://github.com/mill1000/midea-msmart/issues/201)). If you registered through SmartHome, re-register via NetHome Plus before continuing.
+3. **Install msmart-ng** on the Pi:
+   ```bash
+   sudo pip install msmart-ng
+   ```
+4. **Run the setup helper** — it discovers the dongle on the LAN, prompts for your NetHome Plus credentials, fetches the local `token` + `key`, writes the four `HVAC_*` keys to `.env`, and verifies with a refresh:
+   ```bash
+   sudo python3 /usr/lib/cgi-bin/remote-switch/setup_hvac.py
+   ```
+5. Reload the web UI — the "Hangar HVAC" card replaces the "Not configured" placeholder, and HVAC becomes a device option in the scheduler.
+
+mod_wsgi auto-reloads on `.env` changes the next time `switch.py` is touched; if the new card doesn't appear immediately, `sudo systemctl reload apache2` (or `git pull` to bump the file mtime) forces it.
+
+### What's stored in `.env`
+After pairing, four keys are added — don't edit by hand, use `setup_hvac.py` to refresh:
+```
+HVAC_DONGLE_IP=192.168.1.50
+HVAC_DEVICE_ID=123456789012345
+HVAC_TOKEN=<long hex string>
+HVAC_KEY=<long hex string>
+```
+
+### What is "Freeze Prevention"?
+A software preset = Heat mode / 60°F (Midea's heat-mode minimum) / Low fan. msmart-ng does not currently expose Midea's true "8°C heating" anti-freeze flag (it's an IR-only feature on most models), so this is the closest equivalent you can drive over the dongle. Fine for keeping a Colorado hangar above freezing in winter.
+
+### Drift detection
+If someone uses the physical IR remote while you're away, the dongle's reported state diverges from what the web UI last commanded. When this happens, the HVAC card surfaces both the **Reported** state (what the unit is doing now) and **Last commanded** (what was last sent from the web), so you can see at a glance that the physical remote was used.
+
+### Troubleshooting
+- **`setup_hvac.py` finds no devices.** Check the dongle is powered (LED inside the indoor unit), paired via NetHome Plus, and on the same subnet as the Pi.
+- **`Cloud login failed`** during setup. You're probably on a SmartHome account — re-register via NetHome Plus and retry.
+- **HVAC card shows "stale Xs ago".** The dongle isn't replying. Check the indoor unit has power, the dongle hasn't fallen out, and the LAN IP hasn't changed (DHCP). If the IP changed, re-run `setup_hvac.py` to refresh `.env`.
+- **HVAC card shows "Not configured" after pairing.** Verify all four `HVAC_*` keys are present and non-empty in `.env`.
 
 ---
 
@@ -210,6 +266,7 @@ To minimise SD card writes on the Raspberry Pi, all per-minute data is written t
 /run/heater.db                  ← RAM (tmpfs). Volatile. Written every minute.
 /var/lib/heater/heater.db       ← Disk (SD card). Written weekly (flush) + monthly (rollup).
 /run/heater-ambient.tmp         ← Ambient temp cache (15-min TTL, ~50 bytes).
+/run/heater-hvac.json           ← Cached HVAC dongle state (30-sec TTL, ~400 bytes). Optional.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Midea **US-OSK105** WiFi USB dongle (~$30 on Amazon: ASIN [B0GVSPFK1P](https://w
    sudo pip install msmart-ng --break-system-packages
    ```
    The `--break-system-packages` flag is needed on Bookworm and later (PEP 668). For this project's deployment model (system Python under mod_wsgi + root cron) it's the pragmatic choice — a venv would require reconfiguring the WSGI daemon and cron paths.
-4. **Run the setup helper** — it discovers the dongle on the LAN, prompts for your NetHome Plus credentials, fetches the local `token` + `key`, writes the four `HVAC_*` keys to `.env`, and verifies with a refresh:
+4. **Run the setup helper** — it prompts for your NetHome Plus credentials, then in a single round-trip discovers the dongle on the LAN and authenticates it via Midea's cloud (returning the local `token` + `key`). The four `HVAC_*` keys are then written to `.env` and the script verifies with a live refresh:
    ```bash
    sudo python3 /usr/lib/cgi-bin/remote-switch/setup_hvac.py
    ```
@@ -253,8 +253,9 @@ A software preset = Heat mode / 60°F (Midea's heat-mode minimum) / Low fan. msm
 If someone uses the physical IR remote while you're away, the dongle's reported state diverges from what the web UI last commanded. When this happens, the HVAC card surfaces both the **Reported** state (what the unit is doing now) and **Last commanded** (what was last sent from the web), so you can see at a glance that the physical remote was used.
 
 ### Troubleshooting
-- **`setup_hvac.py` finds no devices.** Check the dongle is powered (LED inside the indoor unit), paired via NetHome Plus, and on the same subnet as the Pi.
-- **`Cloud login failed`** during setup. You're probably on a SmartHome account — re-register via NetHome Plus and retry.
+- **`setup_hvac.py` finds no devices.** Check the dongle is powered (LED inside the indoor unit), paired via NetHome Plus, and on the same subnet as the Pi (hangar WiFi often runs an isolated guest network — make sure the Pi and the dongle are on the same one).
+- **Setup fails at "Discovery / cloud auth failed".** Most often a SmartHome vs NetHome Plus account mismatch — re-register via NetHome Plus and retry. If that's not it, double-check the password (case-sensitive) and that you can sign in to the NetHome Plus app on the phone with the same credentials.
+- **`ImportError: cannot import name '...' from 'msmart...'`.** msmart-ng's API has shifted between releases. The wrappers in this repo were verified against `msmart-ng==2025.12.0`. If you're on a much newer version and an import name has moved, see CLAUDE.md ("msmart-ng API surface") for the symbols to grep and pin a working version with `sudo pip install msmart-ng==2025.12.0`.
 - **HVAC card shows "stale Xs ago".** The dongle isn't replying. Check the indoor unit has power, the dongle hasn't fallen out, and the LAN IP hasn't changed (DHCP). If the IP changed, re-run `setup_hvac.py` to refresh `.env`.
 - **HVAC card shows "Not configured" after pairing.** Verify all four `HVAC_*` keys are present and non-empty in `.env`.
 

--- a/aggregate.py
+++ b/aggregate.py
@@ -10,11 +10,12 @@ from statistics import mean
 
 def compute(rows, cutoff, chart_end):
     """
-    Aggregate temperature, heater, and ambient readings into chart-ready data.
+    Aggregate temperature, heater, ambient, fan, and HVAC readings into chart-ready data.
 
     Args:
-        rows:      Iterable of (epoch, temp_c, heater_state, ambient_c).
-                   Any value except epoch may be None.
+        rows:      Iterable of (epoch, temp_c, heater_state, ambient_c, fan_state, ac_state).
+                   Any value except epoch may be None. Older 5-column rows still parse
+                   (ac_state defaults to None).
         cutoff:    Start epoch (inclusive). Rows before this are ignored.
         chart_end: End epoch (exclusive). Rows at/after this are ignored.
 
@@ -22,6 +23,7 @@ def compute(rows, cutoff, chart_end):
         chart_data      list of {x: epoch_ms, y: temp_f}  (15-min bucket avg)
         ambient_data    list of {x: epoch_ms, y: temp_f}  (15-min bucket, 4-bucket rolling avg)
         heater_ranges   list of {xMin: epoch_ms, xMax: epoch_ms}
+        hvac_ranges     list of {xMin: epoch_ms, xMax: epoch_ms}  (any HVAC mode active)
         cold_ranges     list of {xMin: epoch_ms, xMax: epoch_ms}  (temp <= 48°F / 8.89°C)
         temp_stats      dict or None
         ambient_stats   dict or None
@@ -30,25 +32,35 @@ def compute(rows, cutoff, chart_end):
     chart_buckets = {}   # bucket_epoch -> [temp_c]
     amb_buckets = {}     # bucket_epoch -> [ambient_c]
     heater_ranges = []
+    hvac_ranges = []
     cold_ranges = []
 
     temp_vals = []
     amb_vals = []
     on_mins = 0
     fan_on_mins = 0
+    hvac_on_mins = 0
     total_temp_mins = 0
     total_heater_mins = 0
     total_fan_mins = 0
+    total_hvac_mins = 0
 
     in_heater = False
+    in_hvac = False
     in_cold = False
     heater_start = heater_last = 0
+    hvac_start = hvac_last = 0
     cold_start = cold_last = 0
 
     last_epoch = None
 
     for row in sorted(rows, key=lambda r: r[0]):
-        epoch, temp_c, heater_state, ambient_c, fan_state = row[0], row[1], row[2], row[3], row[4] if len(row) > 4 else None
+        epoch       = row[0]
+        temp_c      = row[1]
+        heater_state = row[2]
+        ambient_c   = row[3]
+        fan_state   = row[4] if len(row) > 4 else None
+        ac_state    = row[5] if len(row) > 5 else None
 
         if epoch < cutoff or epoch >= chart_end:
             continue
@@ -99,6 +111,24 @@ def compute(rows, cutoff, chart_end):
             if fan_state == 1:
                 fan_on_mins += 1
 
+        # --- HVAC state (any non-zero mode = on) ---
+        if ac_state is not None:
+            total_hvac_mins += 1
+            hvac_on = ac_state > 0
+            if hvac_on:
+                hvac_on_mins += 1
+            if hvac_on and not in_hvac:
+                hvac_start = epoch
+                in_hvac = True
+            elif not hvac_on and in_hvac:
+                hvac_ranges.append({
+                    "xMin": hvac_start * 1000,
+                    "xMax": (hvac_last + 60) * 1000,
+                })
+                in_hvac = False
+            if hvac_on:
+                hvac_last = epoch
+
         # --- ambient ---
         if ambient_c is not None:
             amb_buckets.setdefault(b, []).append(ambient_c)
@@ -109,6 +139,11 @@ def compute(rows, cutoff, chart_end):
         heater_ranges.append({
             "xMin": heater_start * 1000,
             "xMax": (heater_last + 60) * 1000,
+        })
+    if in_hvac:
+        hvac_ranges.append({
+            "xMin": hvac_start * 1000,
+            "xMax": (hvac_last + 60) * 1000,
         })
     if in_cold:
         cold_ranges.append({
@@ -170,11 +205,14 @@ def compute(rows, cutoff, chart_end):
         }
         if total_fan_mins > 0:
             runtime_stats["fan_on_hrs"] = round(fan_on_mins / 60, 1)
+        if total_hvac_mins > 0:
+            runtime_stats["hvac_on_hrs"] = round(hvac_on_mins / 60, 1)
 
     return {
         "chart_data": chart_data,
         "ambient_data": ambient_data,
         "heater_ranges": heater_ranges,
+        "hvac_ranges": hvac_ranges,
         "cold_ranges": cold_ranges,
         "temp_stats": temp_stats,
         "ambient_stats": ambient_stats,
@@ -190,8 +228,11 @@ def compute_bucketed(rows, cutoff, chart_end):
     per-minute readings into 15-min buckets before Python sees them.
 
     Args:
-        rows:      Iterable of (bucket_epoch, avg_temp_c, avg_ambient_c, avg_heater_state, avg_fan_state)
+        rows:      Iterable of (bucket_epoch, avg_temp_c, avg_ambient_c, avg_heater_state,
+                                avg_fan_state, avg_ac_active)
                    as returned by config.query_bucketed(), sorted by bucket_epoch.
+                   avg_ac_active is the fraction of the bucket the HVAC was in any
+                   non-off mode (binary representation, see config.query_bucketed).
         cutoff:    Start epoch (inclusive).
         chart_end: End epoch (exclusive).
 
@@ -199,6 +240,7 @@ def compute_bucketed(rows, cutoff, chart_end):
         chart_data      list of {x: epoch_ms, y: temp_f}
         ambient_data    list of {x: epoch_ms, y: temp_f}  (4-bucket rolling avg)
         heater_ranges   list of {xMin: epoch_ms, xMax: epoch_ms}
+        hvac_ranges     list of {xMin: epoch_ms, xMax: epoch_ms}
         cold_ranges     list of {xMin: epoch_ms, xMax: epoch_ms}
         fan_ranges      list of {xMin: epoch_ms, xMax: epoch_ms}
     """
@@ -207,18 +249,29 @@ def compute_bucketed(rows, cutoff, chart_end):
     chart_data = []
     ambient_data = []
     heater_ranges = []
+    hvac_ranges = []
     cold_ranges = []
     fan_ranges = []
 
     amb_window = deque(maxlen=4)
     in_heater = False
+    in_hvac = False
     in_cold = False
     in_fan = False
     heater_start = heater_last = 0
+    hvac_start = hvac_last = 0
     cold_start = cold_last = 0
     fan_start = fan_last = 0
 
-    for b, avg_temp_c, avg_ambient_c, avg_heater, avg_fan in rows:
+    for row in rows:
+        # Older bucketed rows may not include avg_ac_active — tolerate 5-tuple input
+        b = row[0]
+        avg_temp_c    = row[1]
+        avg_ambient_c = row[2]
+        avg_heater    = row[3]
+        avg_fan       = row[4]
+        avg_ac_active = row[5] if len(row) > 5 else None
+
         if b < cutoff or b >= chart_end:
             continue
 
@@ -259,6 +312,18 @@ def compute_bucketed(rows, cutoff, chart_end):
             if fan_on:
                 fan_last = b
 
+        # HVAC ranges (avg_ac_active > 0 means HVAC was in some non-off mode this bucket)
+        if avg_ac_active is not None:
+            hvac_on = avg_ac_active > 0
+            if hvac_on and not in_hvac:
+                hvac_start = b
+                in_hvac = True
+            elif not hvac_on and in_hvac:
+                hvac_ranges.append({"xMin": hvac_start * 1000, "xMax": (hvac_last + BUCKET_SECS) * 1000})
+                in_hvac = False
+            if hvac_on:
+                hvac_last = b
+
         # Ambient (4-bucket rolling avg)
         if avg_ambient_c is not None:
             amb_window.append(avg_ambient_c * 1.8 + 32)
@@ -267,6 +332,8 @@ def compute_bucketed(rows, cutoff, chart_end):
     # Close open ranges
     if in_heater:
         heater_ranges.append({"xMin": heater_start * 1000, "xMax": (heater_last + BUCKET_SECS) * 1000})
+    if in_hvac:
+        hvac_ranges.append({"xMin": hvac_start * 1000, "xMax": (hvac_last + BUCKET_SECS) * 1000})
     if in_cold:
         cold_ranges.append({"xMin": cold_start * 1000, "xMax": (cold_last + BUCKET_SECS) * 1000})
     if in_fan:
@@ -276,6 +343,7 @@ def compute_bucketed(rows, cutoff, chart_end):
         "chart_data": chart_data,
         "ambient_data": ambient_data,
         "heater_ranges": heater_ranges,
+        "hvac_ranges": hvac_ranges,
         "cold_ranges": cold_ranges,
         "fan_ranges": fan_ranges,
     }

--- a/config.py
+++ b/config.py
@@ -243,7 +243,8 @@ CREATE TABLE IF NOT EXISTS readings (
     temp_c        REAL,
     heater_state  INTEGER,
     ambient_c     REAL,
-    fan_state     INTEGER
+    fan_state     INTEGER,
+    ac_state      INTEGER
 );
 """
 
@@ -251,7 +252,9 @@ _DISK_SCHEMA = _RAM_SCHEMA + """
 CREATE TABLE IF NOT EXISTS schedules (
     created_epoch  INTEGER PRIMARY KEY,
     execute_epoch  INTEGER NOT NULL,
-    action         TEXT NOT NULL
+    action         TEXT NOT NULL,
+    device         TEXT DEFAULT 'heater',
+    params         TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS monthly_cache (
@@ -272,10 +275,14 @@ def get_ram_db():
     conn = sqlite3.connect(str(RAM_DB))
     conn.execute("PRAGMA journal_mode=MEMORY")
     conn.executescript(_RAM_SCHEMA)
-    try:
-        conn.execute("ALTER TABLE readings ADD COLUMN fan_state INTEGER")
-    except Exception:
-        pass  # column already exists
+    for col_sql in (
+        "ALTER TABLE readings ADD COLUMN fan_state INTEGER",
+        "ALTER TABLE readings ADD COLUMN ac_state INTEGER",
+    ):
+        try:
+            conn.execute(col_sql)
+        except Exception:
+            pass  # column already exists
     return conn
 
 
@@ -292,10 +299,16 @@ def get_db():
     conn = sqlite3.connect(str(DISK_DB))
     conn.execute("PRAGMA journal_mode=DELETE")
     conn.executescript(_DISK_SCHEMA)
-    try:
-        conn.execute("ALTER TABLE readings ADD COLUMN fan_state INTEGER")
-    except Exception:
-        pass  # column already exists
+    for col_sql in (
+        "ALTER TABLE readings ADD COLUMN fan_state INTEGER",
+        "ALTER TABLE readings ADD COLUMN ac_state INTEGER",
+        "ALTER TABLE schedules ADD COLUMN device TEXT DEFAULT 'heater'",
+        "ALTER TABLE schedules ADD COLUMN params TEXT DEFAULT ''",
+    ):
+        try:
+            conn.execute(col_sql)
+        except Exception:
+            pass  # column already exists
 
     if RAM_DB.exists():
         conn.execute(f"ATTACH DATABASE '{RAM_DB}' AS ram")
@@ -305,13 +318,18 @@ def get_db():
                 temp_c        REAL,
                 heater_state  INTEGER,
                 ambient_c     REAL,
-                fan_state     INTEGER
+                fan_state     INTEGER,
+                ac_state      INTEGER
             );
         """)
-        try:
-            conn.execute("ALTER TABLE ram.readings ADD COLUMN fan_state INTEGER")
-        except Exception:
-            pass  # column already exists
+        for col_sql in (
+            "ALTER TABLE ram.readings ADD COLUMN fan_state INTEGER",
+            "ALTER TABLE ram.readings ADD COLUMN ac_state INTEGER",
+        ):
+            try:
+                conn.execute(col_sql)
+            except Exception:
+                pass  # column already exists
 
     return conn
 
@@ -323,17 +341,17 @@ def query_readings(conn, since_epoch, until_epoch):
     """
     if _has_ram(conn):
         sql = """
-            SELECT epoch, temp_c, heater_state, ambient_c, fan_state FROM readings
+            SELECT epoch, temp_c, heater_state, ambient_c, fan_state, ac_state FROM readings
             WHERE epoch >= ? AND epoch < ?
             UNION
-            SELECT epoch, temp_c, heater_state, ambient_c, fan_state FROM ram.readings
+            SELECT epoch, temp_c, heater_state, ambient_c, fan_state, ac_state FROM ram.readings
             WHERE epoch >= ? AND epoch < ?
             ORDER BY epoch
         """
         return conn.execute(sql, (since_epoch, until_epoch, since_epoch, until_epoch)).fetchall()
     else:
         return conn.execute(
-            "SELECT epoch, temp_c, heater_state, ambient_c, fan_state FROM readings "
+            "SELECT epoch, temp_c, heater_state, ambient_c, fan_state, ac_state FROM readings "
             "WHERE epoch >= ? AND epoch < ? ORDER BY epoch",
             (since_epoch, until_epoch)
         ).fetchall()
@@ -351,18 +369,23 @@ def query_bucketed(conn, since_epoch, until_epoch, bucket_secs=900):
     (0.0–1.0), or None if heater_state was never logged in this bucket.
     """
     bs = bucket_secs
+    # ac_active = 1.0 when HVAC is doing anything (mode != off); averaged over
+    # the bucket gives the fraction of minutes the HVAC was on. Multi-mode
+    # detail (heat vs cool) is dropped at this resolution to keep the chart
+    # band binary like heater_state / fan_state.
     select = (
         f"(epoch/{bs})*{bs},"
-        " AVG(temp_c), AVG(ambient_c), AVG(heater_state), AVG(fan_state)"
+        " AVG(temp_c), AVG(ambient_c), AVG(heater_state), AVG(fan_state),"
+        " AVG(CASE WHEN ac_state > 0 THEN 1.0 ELSE 0.0 END)"
     )
     group = f"GROUP BY (epoch/{bs})*{bs} ORDER BY (epoch/{bs})*{bs}"
     if _has_ram(conn):
         sql = (
             f"SELECT {select} FROM ("
-            "SELECT epoch, temp_c, heater_state, ambient_c, fan_state FROM readings"
+            "SELECT epoch, temp_c, heater_state, ambient_c, fan_state, ac_state FROM readings"
             " WHERE epoch >= ? AND epoch < ?"
             " UNION"
-            " SELECT epoch, temp_c, heater_state, ambient_c, fan_state FROM ram.readings"
+            " SELECT epoch, temp_c, heater_state, ambient_c, fan_state, ac_state FROM ram.readings"
             " WHERE epoch >= ? AND epoch < ?"
             f") {group}"
         )

--- a/hvac.py
+++ b/hvac.py
@@ -114,16 +114,24 @@ def _msmart_fans():
     }
 
 
-def _open_device():
+async def _open_device():
+    """Construct + authenticate an AirConditioner instance against the dongle.
+
+    msmart-ng 2025.12.0 makes authenticate() async (it performs a handshake
+    with the dongle), so this whole helper is async and lives inside the
+    async closures in get_state / set_state.
+    """
     from msmart.device import AirConditioner as AC
     e = config.load_env()
     dev = AC(
         ip=e["HVAC_DONGLE_IP"].strip(),
-        port=LAN_PORT,
         device_id=int(e["HVAC_DEVICE_ID"].strip()),
+        port=LAN_PORT,
     )
-    dev.token = e["HVAC_TOKEN"].strip()
-    dev.key   = e["HVAC_KEY"].strip()
+    await dev.authenticate(
+        e["HVAC_TOKEN"].strip(),
+        e["HVAC_KEY"].strip(),
+    )
     return dev
 
 
@@ -225,7 +233,7 @@ def get_state(force=False):
 
     try:
         async def _fetch():
-            dev = _open_device()
+            dev = await _open_device()
             await dev.refresh()
             return _device_to_dict(dev)
 
@@ -272,7 +280,7 @@ def set_state(power=None, mode=None, target_f=None, fan_speed=None):
 
     try:
         async def _apply():
-            dev = _open_device()
+            dev = await _open_device()
             await dev.refresh()
 
             if requested["power"] is not None:

--- a/hvac.py
+++ b/hvac.py
@@ -1,0 +1,369 @@
+"""
+hvac.py — Hangar HVAC (Durastar DRAW33F2A mini-split) control via Midea WiFi dongle.
+
+Distinct from the engine-block heater (config.GPIO_PIN) and the exhaust fan
+(config.FAN_GPIO_PIN). This module talks to the Durastar's Midea-OEM WiFi
+dongle on the LAN over TCP/6444 using msmart-ng.
+
+If HVAC_DONGLE_IP / HVAC_DEVICE_ID / HVAC_TOKEN / HVAC_KEY are not all set in
+.env, is_configured() returns False and every function is a safe no-op. The
+UI hides the HVAC card in that state.
+
+State is cached in /run/heater-hvac.json with a 30s TTL so page loads don't
+hammer the dongle. The cache stores both:
+    reported   — what the dongle says the unit is doing right now
+    commanded  — the most recent set_state() we sent
+The UI shows reported by default; commanded is surfaced only when they differ
+(catches drift from someone using the physical remote).
+"""
+
+import asyncio
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import config
+
+# ---------------------------------------------------------------------------
+# Paths and constants
+# ---------------------------------------------------------------------------
+HVAC_CACHE     = Path("/run/heater-hvac.json")
+CACHE_TTL_SECS = 30
+LAN_PORT       = 6444
+
+# Stable, lowercase mode/fan tokens — used in .env, schedules.params JSON,
+# and query strings. Keep these short and human-readable.
+MODE_AUTO   = "auto"
+MODE_COOL   = "cool"
+MODE_DRY    = "dry"
+MODE_HEAT   = "heat"
+MODE_FAN    = "fan"
+MODE_FREEZE = "freeze"  # software preset, see _resolve_freeze()
+
+ALL_MODES = [MODE_AUTO, MODE_COOL, MODE_DRY, MODE_HEAT, MODE_FAN, MODE_FREEZE]
+
+MODE_LABELS = {
+    MODE_AUTO:   "Auto",
+    MODE_COOL:   "Cool",
+    MODE_DRY:    "Dry",
+    MODE_HEAT:   "Heat",
+    MODE_FAN:    "Fan only",
+    MODE_FREEZE: "Freeze Prevention",
+}
+
+FAN_AUTO = "auto"
+FAN_LOW  = "low"
+FAN_MED  = "med"
+FAN_HIGH = "high"
+ALL_FANS = [FAN_AUTO, FAN_LOW, FAN_MED, FAN_HIGH]
+FAN_LABELS = {FAN_AUTO: "Auto", FAN_LOW: "Low", FAN_MED: "Medium", FAN_HIGH: "High"}
+
+# UI temp range — user inputs Fahrenheit. Conversions to °C happen at the boundary.
+TEMP_MIN_F = 60
+TEMP_MAX_F = 86
+
+# Freeze Prevention preset (msmart-ng has no true anti-freeze enum)
+FREEZE_TARGET_C = 16  # 60°F = Midea heat-mode minimum
+FREEZE_FAN      = FAN_LOW
+
+# Integer codes for the readings.ac_state column. log_temp.py logs these every
+# minute; aggregate.py renders them as a chart band like heater_state / fan_state.
+AC_STATE_OFF  = 0
+AC_STATE_HEAT = 1
+AC_STATE_COOL = 2
+AC_STATE_FAN  = 3
+AC_STATE_DRY  = 4
+AC_STATE_AUTO = 5
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def is_configured():
+    """True iff all four .env keys are set. Cheap — safe to call per request."""
+    e = config.load_env()
+    return all(e.get(k, "").strip() for k in (
+        "HVAC_DONGLE_IP", "HVAC_DEVICE_ID", "HVAC_TOKEN", "HVAC_KEY"
+    ))
+
+
+# ---------------------------------------------------------------------------
+# msmart-ng adapter — lazy import so the rest of the app boots without it
+# ---------------------------------------------------------------------------
+
+def _msmart_modes():
+    from msmart.device import AirConditioner as AC
+    return {
+        MODE_AUTO: AC.OperationalMode.AUTO,
+        MODE_COOL: AC.OperationalMode.COOL,
+        MODE_DRY:  AC.OperationalMode.DRY,
+        MODE_HEAT: AC.OperationalMode.HEAT,
+        MODE_FAN:  AC.OperationalMode.FAN_ONLY,
+    }
+
+
+def _msmart_fans():
+    from msmart.device import AirConditioner as AC
+    return {
+        FAN_AUTO: AC.FanSpeed.AUTO,
+        FAN_LOW:  AC.FanSpeed.LOW,
+        FAN_MED:  AC.FanSpeed.MEDIUM,
+        FAN_HIGH: AC.FanSpeed.HIGH,
+    }
+
+
+def _open_device():
+    from msmart.device import AirConditioner as AC
+    e = config.load_env()
+    dev = AC(
+        ip=e["HVAC_DONGLE_IP"].strip(),
+        port=LAN_PORT,
+        device_id=int(e["HVAC_DEVICE_ID"].strip()),
+    )
+    dev.token = e["HVAC_TOKEN"].strip()
+    dev.key   = e["HVAC_KEY"].strip()
+    return dev
+
+
+def _run_async(coro):
+    """asyncio.run() wrapper — keeps mod_wsgi sync handler path intact."""
+    return asyncio.run(coro)
+
+
+def _device_to_dict(dev):
+    """Translate an msmart-ng AirConditioner's live attributes to a plain dict."""
+    inv_modes = {v: k for k, v in _msmart_modes().items()}
+    inv_fans  = {v: k for k, v in _msmart_fans().items()}
+
+    target_c = float(dev.target_temperature) if dev.target_temperature is not None else None
+    indoor_c = float(dev.indoor_temperature) if dev.indoor_temperature is not None else None
+
+    return {
+        "power":     bool(dev.power_state),
+        "mode":      inv_modes.get(dev.operational_mode, str(dev.operational_mode)),
+        "target_c":  target_c,
+        "target_f":  round(target_c * 9 / 5 + 32, 1) if target_c is not None else None,
+        "fan_speed": inv_fans.get(dev.fan_speed, str(dev.fan_speed)),
+        "indoor_c":  indoor_c,
+        "indoor_f":  round(indoor_c * 9 / 5 + 32, 1) if indoor_c is not None else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cache (single JSON file in /run, holds reported + commanded views)
+# ---------------------------------------------------------------------------
+
+def _read_cache():
+    try:
+        return json.loads(HVAC_CACHE.read_text())
+    except (OSError, ValueError):
+        return {"reported": None, "commanded": None}
+
+
+def _write_cache(cache):
+    try:
+        HVAC_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        HVAC_CACHE.write_text(json.dumps(cache))
+        os.chmod(str(HVAC_CACHE), 0o664)
+    except OSError:
+        pass
+
+
+def _now_epoch():
+    return int(datetime.now().timestamp())
+
+
+def _save_reported(state):
+    cache = _read_cache()
+    state = dict(state)
+    state["epoch"] = _now_epoch()
+    cache["reported"] = state
+    _write_cache(cache)
+
+
+def _save_commanded(state):
+    cache = _read_cache()
+    state = dict(state)
+    state["epoch"] = _now_epoch()
+    cache["commanded"] = state
+    _write_cache(cache)
+
+
+# ---------------------------------------------------------------------------
+# Public API — sync, safe to call from WSGI / cron
+# ---------------------------------------------------------------------------
+
+def get_state(force=False):
+    """
+    Return current HVAC state as a dict, or None if not configured.
+
+    Shape:
+        {
+          "reported":  {power, mode, target_c, target_f, fan_speed,
+                        indoor_c, indoor_f, epoch} | None,
+          "commanded": {power, mode, target_c, target_f, fan_speed, epoch} | None,
+          "stale":     bool,        # True if reported came from cache after a fetch failure
+          "age_secs":  int,         # how old the reported value is
+          "diverged":  bool,        # True if commanded differs from reported in any meaningful field
+        }
+
+    If force=False and the cached reported value is < CACHE_TTL_SECS old,
+    skip the network round-trip. On dongle error, return whatever's cached
+    with stale=True; never raise.
+    """
+    if not is_configured():
+        return None
+
+    cache    = _read_cache()
+    reported = cache.get("reported")
+    age      = (_now_epoch() - reported["epoch"]) if reported and "epoch" in reported else None
+
+    if not force and reported is not None and age is not None and age < CACHE_TTL_SECS:
+        return _decorate(cache, age_secs=age, stale=False)
+
+    try:
+        async def _fetch():
+            dev = _open_device()
+            await dev.refresh()
+            return _device_to_dict(dev)
+
+        fresh = _run_async(_fetch())
+        _save_reported(fresh)
+        cache = _read_cache()
+        return _decorate(cache, age_secs=0, stale=False)
+    except Exception:
+        if reported is not None:
+            return _decorate(cache, age_secs=(age or 0), stale=True)
+        return None
+
+
+def set_state(power=None, mode=None, target_f=None, fan_speed=None):
+    """
+    Apply a partial state change. Any None argument keeps the dongle's current value.
+
+    mode='freeze' triggers the Freeze Prevention preset (Heat / 60°F / Low / On)
+    and overrides the other args. Returns True on success, False on error.
+
+    On success, both reported and commanded are persisted so the UI can show
+    drift if the dongle later reports something different.
+    """
+    if not is_configured():
+        return False
+
+    if mode == MODE_FREEZE:
+        power, mode, target_f, fan_speed = _resolve_freeze()
+
+    msmart_modes = None
+    msmart_fans  = None
+    try:
+        msmart_modes = _msmart_modes()
+        msmart_fans  = _msmart_fans()
+    except Exception:
+        return False
+
+    requested = {
+        "power":     bool(power) if power is not None else None,
+        "mode":      mode if (mode is not None and mode in msmart_modes) else None,
+        "target_f":  float(target_f) if target_f is not None else None,
+        "fan_speed": fan_speed if (fan_speed is not None and fan_speed in msmart_fans) else None,
+    }
+
+    try:
+        async def _apply():
+            dev = _open_device()
+            await dev.refresh()
+
+            if requested["power"] is not None:
+                dev.power_state = requested["power"]
+            if requested["mode"] is not None:
+                dev.operational_mode = msmart_modes[requested["mode"]]
+            if requested["target_f"] is not None:
+                dev.target_temperature = _f_to_c(requested["target_f"])
+            if requested["fan_speed"] is not None:
+                dev.fan_speed = msmart_fans[requested["fan_speed"]]
+
+            await dev.apply()
+            return _device_to_dict(dev)
+
+        post = _run_async(_apply())
+        _save_reported(post)
+
+        # Build commanded view by overlaying requested fields on reported result
+        commanded = {
+            "power":     post["power"]     if requested["power"]     is None else requested["power"],
+            "mode":      post["mode"]      if requested["mode"]      is None else requested["mode"],
+            "target_c":  post["target_c"]  if requested["target_f"]  is None else _f_to_c(requested["target_f"]),
+            "target_f":  post["target_f"]  if requested["target_f"]  is None else round(requested["target_f"], 1),
+            "fan_speed": post["fan_speed"] if requested["fan_speed"] is None else requested["fan_speed"],
+        }
+        _save_commanded(commanded)
+        return True
+    except Exception:
+        return False
+
+
+def state_for_log():
+    """
+    Return integer for readings.ac_state, suitable for log_temp.py to write
+    into the per-minute row. Returns None if HVAC not configured or unreachable
+    (so the column stays NULL rather than mis-recorded as 0/off).
+    """
+    if not is_configured():
+        return None
+    s = get_state()
+    if s is None or s.get("reported") is None:
+        return None
+    r = s["reported"]
+    if not r.get("power"):
+        return AC_STATE_OFF
+    return {
+        MODE_HEAT: AC_STATE_HEAT,
+        MODE_COOL: AC_STATE_COOL,
+        MODE_FAN:  AC_STATE_FAN,
+        MODE_DRY:  AC_STATE_DRY,
+        MODE_AUTO: AC_STATE_AUTO,
+    }.get(r.get("mode"), AC_STATE_OFF)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _decorate(cache, age_secs, stale):
+    """Add UI-facing flags (stale, age_secs, diverged) to the cache view."""
+    out = {
+        "reported":  cache.get("reported"),
+        "commanded": cache.get("commanded"),
+        "stale":     stale,
+        "age_secs":  age_secs,
+        "diverged":  _diverged(cache.get("reported"), cache.get("commanded")),
+    }
+    return out
+
+
+def _diverged(reported, commanded):
+    """True iff commanded was set and differs meaningfully from reported."""
+    if not reported or not commanded:
+        return False
+    fields = ("power", "mode", "fan_speed")
+    for f in fields:
+        if reported.get(f) != commanded.get(f):
+            return True
+    # Compare temps with a 0.5°C tolerance (dongle sometimes rounds half-degrees)
+    rt = reported.get("target_c")
+    ct = commanded.get("target_c")
+    if rt is not None and ct is not None and abs(rt - ct) > 0.5:
+        return True
+    return False
+
+
+def _f_to_c(f):
+    return round((float(f) - 32) * 5 / 9, 1)
+
+
+def _resolve_freeze():
+    """Return (power, mode, target_f, fan) tuple for the Freeze Prevention preset."""
+    target_f = FREEZE_TARGET_C * 9 / 5 + 32
+    return True, MODE_HEAT, round(target_f, 1), FREEZE_FAN

--- a/log_temp.py
+++ b/log_temp.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 import aggregate
 import config
+import hvac
 
 
 def _month_bounds(d):
@@ -163,17 +164,33 @@ def do_log():
 
         conn = config.get_db()
         due = conn.execute(
-            "SELECT created_epoch, action FROM schedules WHERE execute_epoch <= ?",
+            "SELECT created_epoch, action, COALESCE(device, 'heater'), COALESCE(params, '') "
+            "FROM schedules WHERE execute_epoch <= ?",
             (now_epoch,)
         ).fetchall()
 
-        for created_epoch, action in due:
-            if action in ("0", "1"):
+        for created_epoch, action, device, params in due:
+            if device == "heater":
+                # Engine-block heater: action is "0" or "1"
+                if action in ("0", "1"):
+                    try:
+                        config.write_gpio(action)
+                        heater_state = int(action)
+                    except (PermissionError, OSError):
+                        pass
+            elif device == "hvac":
+                # Hangar HVAC: params is JSON {power, mode, target_f, fan_speed}
                 try:
-                    config.write_gpio(action)
-                    heater_state = int(action)
-                except (PermissionError, OSError):
+                    p = json.loads(params) if params else {}
+                    hvac.set_state(
+                        power=p.get("power"),
+                        mode=p.get("mode"),
+                        target_f=p.get("target_f"),
+                        fan_speed=p.get("fan_speed"),
+                    )
+                except Exception:
                     pass
+
             conn.execute(
                 "DELETE FROM schedules WHERE created_epoch = ?",
                 (created_epoch,)
@@ -219,12 +236,15 @@ def do_log():
             except (PermissionError, OSError):
                 pass
 
+    # Read HVAC mode (None if not configured / dongle unreachable)
+    ac_state = hvac.state_for_log()
+
     # Write reading to RAM db
     ram_conn = config.get_ram_db()
     ram_conn.execute(
-        "INSERT OR REPLACE INTO readings (epoch, temp_c, heater_state, ambient_c, fan_state) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (now_epoch, temp_c, heater_state, ambient_c, fan_state)
+        "INSERT OR REPLACE INTO readings (epoch, temp_c, heater_state, ambient_c, fan_state, ac_state) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (now_epoch, temp_c, heater_state, ambient_c, fan_state, ac_state)
     )
     ram_conn.commit()
     ram_conn.close()

--- a/setup_hvac.py
+++ b/setup_hvac.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+setup_hvac.py — One-time pairing helper for the Durastar HVAC WiFi dongle.
+
+Run on the Pi AFTER:
+  1. The Midea US-OSK105 dongle is plugged into the indoor unit's WiFi port.
+  2. You have paired the dongle once via the NetHome Plus app on your phone
+     (NOT SmartHome — its get_token endpoint is currently broken; see msmart-ng
+     issue #201).
+  3. msmart-ng is installed on the Pi:  pip install msmart-ng
+
+What this does:
+  - Discovers the dongle on the LAN (UDP broadcast).
+  - Prompts for your NetHome Plus email/password.
+  - Fetches the local token + key from Midea's cloud (one-time round-trip).
+  - Writes HVAC_DONGLE_IP / HVAC_DEVICE_ID / HVAC_TOKEN / HVAC_KEY to .env.
+  - Tests a refresh against the dongle and prints the current HVAC state.
+
+After this completes successfully, the WSGI app picks up the .env values on
+the next request — no Apache restart needed.
+"""
+
+import asyncio
+import getpass
+import sys
+from pathlib import Path
+
+import config
+
+
+def _die(msg, code=1):
+    print(f"setup_hvac: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _check_msmart_installed():
+    try:
+        import msmart  # noqa: F401
+    except ImportError:
+        _die("msmart-ng not installed. Run: pip install msmart-ng")
+
+
+def _existing_keys():
+    e = config.load_env()
+    return {k: e.get(k, "").strip() for k in (
+        "HVAC_DONGLE_IP", "HVAC_DEVICE_ID", "HVAC_TOKEN", "HVAC_KEY"
+    )}
+
+
+def _confirm_overwrite():
+    have = _existing_keys()
+    if any(have.values()):
+        print("Existing HVAC keys found in .env:")
+        for k, v in have.items():
+            shown = (v[:8] + "…") if len(v) > 12 else v
+            print(f"  {k} = {shown or '(empty)'}")
+        ans = input("\nOverwrite? [y/N] ").strip().lower()
+        if ans != "y":
+            print("Aborted.")
+            sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+async def _discover():
+    from msmart.discover import Discover
+    print("Scanning LAN for Midea/Durastar dongle (UDP broadcast, ~5s)...")
+    devices = await Discover.discover()
+    if not devices:
+        _die("No devices found. Check that the dongle is powered, paired via "
+             "NetHome Plus, and on the same subnet as the Pi.")
+    return devices
+
+
+def _pick_device(devices):
+    devices = list(devices)
+    if len(devices) == 1:
+        d = devices[0]
+        print(f"Found 1 device: id={d.id} ip={d.ip} type=0x{d.type:02x}")
+        return d
+    print(f"Found {len(devices)} devices:")
+    for i, d in enumerate(devices):
+        print(f"  [{i}] id={d.id} ip={d.ip} type=0x{d.type:02x}")
+    while True:
+        ans = input(f"Pick one [0-{len(devices)-1}]: ").strip()
+        try:
+            return devices[int(ans)]
+        except (ValueError, IndexError):
+            print("Invalid choice.")
+
+
+# ---------------------------------------------------------------------------
+# Cloud token fetch (NetHome Plus)
+# ---------------------------------------------------------------------------
+
+async def _fetch_token_key(device_id):
+    from msmart.cloud import Cloud
+
+    print("\nFetching local token+key from NetHome Plus cloud (one-time).")
+    print("Use the SAME credentials you used in the NetHome Plus phone app.")
+    email    = input("NetHome Plus email: ").strip()
+    password = getpass.getpass("NetHome Plus password: ")
+
+    cloud = Cloud(email, password, account="NetHomePlus")
+    try:
+        await cloud.login()
+    except Exception as e:
+        _die(f"Cloud login failed: {e}\n"
+             "Verify credentials. If you registered through SmartHome, that "
+             "account type currently fails — re-register via NetHome Plus.")
+
+    try:
+        token, key = await cloud.get_token(str(device_id))
+    except Exception as e:
+        _die(f"Token fetch failed for device {device_id}: {e}")
+
+    return token, key
+
+
+# ---------------------------------------------------------------------------
+# .env update
+# ---------------------------------------------------------------------------
+
+def _update_env(ip, device_id, token, key):
+    """Replace or append HVAC_* keys in .env. Preserves other keys."""
+    env_file = config.SCRIPT_DIR / ".env"
+    lines = []
+    if env_file.exists():
+        with env_file.open() as f:
+            for line in f:
+                stripped = line.strip()
+                if any(stripped.startswith(k + "=") for k in (
+                    "HVAC_DONGLE_IP", "HVAC_DEVICE_ID", "HVAC_TOKEN", "HVAC_KEY"
+                )):
+                    continue
+                lines.append(line.rstrip("\n"))
+
+    if lines and lines[-1] != "":
+        lines.append("")
+    lines += [
+        f"HVAC_DONGLE_IP={ip}",
+        f"HVAC_DEVICE_ID={device_id}",
+        f"HVAC_TOKEN={token}",
+        f"HVAC_KEY={key}",
+    ]
+    env_file.write_text("\n".join(lines) + "\n")
+    print(f"\nWrote 4 HVAC_* keys to {env_file}")
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+async def _verify():
+    import hvac
+    print("\nVerifying — fetching current state from dongle...")
+    state = hvac.get_state(force=True)
+    if state is None or state.get("reported") is None:
+        _die("Verification failed — could not read state from dongle.")
+    r = state["reported"]
+    print("OK.")
+    print(f"  Power:   {'ON' if r.get('power') else 'OFF'}")
+    print(f"  Mode:    {r.get('mode')}")
+    print(f"  Target:  {r.get('target_f')}°F ({r.get('target_c')}°C)")
+    print(f"  Fan:     {r.get('fan_speed')}")
+    if r.get("indoor_f") is not None:
+        print(f"  Indoor:  {r.get('indoor_f')}°F ({r.get('indoor_c')}°C)")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def _main_async():
+    _check_msmart_installed()
+    _confirm_overwrite()
+
+    devices = await _discover()
+    device  = _pick_device(devices)
+
+    token, key = await _fetch_token_key(device.id)
+    _update_env(device.ip, device.id, token, key)
+
+    await _verify()
+    print("\nDone. The WSGI app will pick up the new .env on its next request.")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(_main_async())
+    except KeyboardInterrupt:
+        print("\nAborted.")
+        sys.exit(130)

--- a/setup_hvac.py
+++ b/setup_hvac.py
@@ -61,62 +61,66 @@ def _confirm_overwrite():
 
 
 # ---------------------------------------------------------------------------
-# Discovery
+# Discovery + cloud authentication (single call)
 # ---------------------------------------------------------------------------
+#
+# msmart-ng 2025.12.0's Discover.discover() does the cloud handshake itself
+# when given account+password (auto_connect=True is the default). The returned
+# devices come back with .token and .key already populated — no separate
+# get_token() round-trip needed.
 
-async def _discover():
+async def _discover_authenticated():
     from msmart.discover import Discover
-    print("Scanning LAN for Midea/Durastar dongle (UDP broadcast, ~5s)...")
-    devices = await Discover.discover()
+
+    print("Sign in with NetHome Plus credentials.")
+    print("Use the SAME account you paired the dongle with on the phone app.")
+    print("(NOT SmartHome — see msmart-ng issue #201.)")
+    email    = input("NetHome Plus email: ").strip()
+    password = getpass.getpass("NetHome Plus password: ")
+
+    print("\nDiscovering & authenticating dongle (UDP broadcast + cloud handshake, ~10s)...")
+    try:
+        devices = await Discover.discover(
+            account=email,
+            password=password,
+            auto_connect=True,
+        )
+    except Exception as e:
+        _die(f"Discovery / cloud auth failed: {e}\n"
+             "If credentials look right but auth still fails, you may be on a "
+             "SmartHome account — re-register via NetHome Plus and try again.")
+
     if not devices:
-        _die("No devices found. Check that the dongle is powered, paired via "
-             "NetHome Plus, and on the same subnet as the Pi.")
+        _die("No devices discovered. Check that the dongle is powered, paired "
+             "via NetHome Plus, and on the same subnet as the Pi.")
     return devices
+
+
+def _device_type_str(d):
+    """Format the device type for display — handles enum or int."""
+    t = getattr(d, "type", None)
+    if t is None:
+        return "?"
+    if isinstance(t, int):
+        return f"0x{t:02x}"
+    return str(t)
 
 
 def _pick_device(devices):
     devices = list(devices)
     if len(devices) == 1:
         d = devices[0]
-        print(f"Found 1 device: id={d.id} ip={d.ip} type=0x{d.type:02x}")
+        print(f"Found 1 device: id={d.id} ip={d.ip} type={_device_type_str(d)}")
         return d
     print(f"Found {len(devices)} devices:")
     for i, d in enumerate(devices):
-        print(f"  [{i}] id={d.id} ip={d.ip} type=0x{d.type:02x}")
+        print(f"  [{i}] id={d.id} ip={d.ip} type={_device_type_str(d)}")
     while True:
         ans = input(f"Pick one [0-{len(devices)-1}]: ").strip()
         try:
             return devices[int(ans)]
         except (ValueError, IndexError):
             print("Invalid choice.")
-
-
-# ---------------------------------------------------------------------------
-# Cloud token fetch (NetHome Plus)
-# ---------------------------------------------------------------------------
-
-async def _fetch_token_key(device_id):
-    from msmart.cloud import Cloud
-
-    print("\nFetching local token+key from NetHome Plus cloud (one-time).")
-    print("Use the SAME credentials you used in the NetHome Plus phone app.")
-    email    = input("NetHome Plus email: ").strip()
-    password = getpass.getpass("NetHome Plus password: ")
-
-    cloud = Cloud(email, password, account="NetHomePlus")
-    try:
-        await cloud.login()
-    except Exception as e:
-        _die(f"Cloud login failed: {e}\n"
-             "Verify credentials. If you registered through SmartHome, that "
-             "account type currently fails — re-register via NetHome Plus.")
-
-    try:
-        token, key = await cloud.get_token(str(device_id))
-    except Exception as e:
-        _die(f"Token fetch failed for device {device_id}: {e}")
-
-    return token, key
 
 
 # ---------------------------------------------------------------------------
@@ -177,11 +181,14 @@ async def _main_async():
     _check_msmart_installed()
     _confirm_overwrite()
 
-    devices = await _discover()
+    devices = await _discover_authenticated()
     device  = _pick_device(devices)
 
-    token, key = await _fetch_token_key(device.id)
-    _update_env(device.ip, device.id, token, key)
+    if not device.token or not device.key:
+        _die("Device discovered but no token/key returned. The cloud auth step "
+             "didn't populate credentials — try re-pairing on NetHome Plus.")
+
+    _update_env(device.ip, device.id, device.token, device.key)
 
     await _verify()
     print("\nDone. The WSGI app will pick up the new .env on its next request.")

--- a/switch.py
+++ b/switch.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 import aggregate
 import config
+import hvac
 
 try:
     from markupsafe import Markup
@@ -301,13 +302,32 @@ def _handle(environ):
         config.write_fan_mode("auto")
         _redirect("switch.py")
 
+    # --- HVAC apply (immediate state change for Hangar HVAC) ---
+    if qs.get("hvac_apply") == "1" and hvac.is_configured():
+        hvac_mode = qs.get("hvac_mode", "")
+        if hvac_mode == hvac.MODE_FREEZE:
+            hvac.set_state(mode=hvac.MODE_FREEZE)
+        else:
+            try:
+                target_f = float(qs.get("hvac_target_f", "")) if qs.get("hvac_target_f") else None
+            except ValueError:
+                target_f = None
+            hvac.set_state(
+                power=(qs.get("hvac_power") == "1") if qs.get("hvac_power") in ("0", "1") else None,
+                mode=hvac_mode if hvac_mode in hvac.ALL_MODES else None,
+                target_f=target_f,
+                fan_speed=qs.get("hvac_fan_speed") if qs.get("hvac_fan_speed") in hvac.ALL_FANS else None,
+            )
+        _redirect("switch.py")
+
     # --- Schedule add ---
     now_epoch = int(datetime.now().timestamp())
     sched_msg = Markup("")
 
-    sched_dt_raw = qs.get("sched_dt", "")
-    sched_action = qs.get("sched_action", "")
-    if sched_dt_raw and sched_action in ("0", "1"):
+    sched_dt_raw  = qs.get("sched_dt", "")
+    sched_device  = qs.get("sched_device", "heater")
+    sched_action  = qs.get("sched_action", "")
+    if sched_dt_raw and (sched_device == "hvac" or sched_action in ("0", "1")):
         sched_dt_decoded = urllib.parse.unquote_plus(sched_dt_raw)
         try:
             sched_epoch = int(
@@ -318,12 +338,50 @@ def _handle(environ):
                     '<div class="alert alert-warning alert-sm py-1 mb-2">'
                     "Cannot schedule in the past.</div>"
                 )
+            elif sched_device == "hvac":
+                hvac_mode = qs.get("sched_hvac_mode", "")
+                if hvac_mode not in hvac.ALL_MODES:
+                    sched_msg = Markup(
+                        '<div class="alert alert-danger alert-sm py-1 mb-2">'
+                        "Invalid HVAC mode.</div>"
+                    )
+                else:
+                    try:
+                        sched_target_f = float(qs.get("sched_hvac_target_f", "")) \
+                            if qs.get("sched_hvac_target_f") else None
+                    except ValueError:
+                        sched_target_f = None
+                    sched_fan = qs.get("sched_hvac_fan_speed", "auto")
+                    if sched_fan not in hvac.ALL_FANS:
+                        sched_fan = "auto"
+                    sched_power = qs.get("sched_hvac_power") == "1"
+                    if hvac_mode == hvac.MODE_FREEZE:
+                        params = {"mode": hvac.MODE_FREEZE}
+                    else:
+                        params = {
+                            "power": sched_power,
+                            "mode": hvac_mode,
+                            "fan_speed": sched_fan,
+                        }
+                        if sched_target_f is not None:
+                            params["target_f"] = sched_target_f
+                    conn = config.get_db()
+                    conn.execute(
+                        "INSERT OR REPLACE INTO schedules "
+                        "(created_epoch, execute_epoch, action, device, params) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        (now_epoch, sched_epoch, "set", "hvac", json.dumps(params)),
+                    )
+                    conn.commit()
+                    conn.close()
+                    _redirect("switch.py")
             else:
                 conn = config.get_db()
                 conn.execute(
-                    "INSERT OR REPLACE INTO schedules (created_epoch, execute_epoch, action) "
-                    "VALUES (?, ?, ?)",
-                    (now_epoch, sched_epoch, sched_action),
+                    "INSERT OR REPLACE INTO schedules "
+                    "(created_epoch, execute_epoch, action, device, params) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (now_epoch, sched_epoch, sched_action, "heater", ""),
                 )
                 conn.commit()
                 conn.close()
@@ -389,21 +447,32 @@ def _handle(environ):
             amb_f = amb_c * 1.8 + 32
             ambient_display = f"{amb_c:.1f} \u00b0C | {amb_f:.1f} \u00b0F"
 
+    # --- HVAC state ---
+    hvac_configured = hvac.is_configured()
+    hvac_state = hvac.get_state() if hvac_configured else None
+
     # --- Pending schedules ---
     conn = config.get_db()
     pending_rows = conn.execute(
-        "SELECT created_epoch, execute_epoch, action FROM schedules ORDER BY execute_epoch"
+        "SELECT created_epoch, execute_epoch, action, "
+        "COALESCE(device, 'heater'), COALESCE(params, '') "
+        "FROM schedules ORDER BY execute_epoch"
     ).fetchall()
     conn.close()
 
     pending_sched_rows = []
-    for created_epoch, execute_epoch, action in pending_rows:
-        action_label = "Turn ON" if action == "1" else "Turn OFF"
+    for created_epoch, execute_epoch, action, device, params in pending_rows:
+        if device == "hvac":
+            action_label = _hvac_sched_label(params)
+            badge = '<span class="badge bg-info text-dark me-1">HVAC</span>'
+        else:
+            action_label = "Turn ON" if action == "1" else "Turn OFF"
+            badge = '<span class="badge bg-secondary me-1">Heater</span>'
         sched_time = datetime.fromtimestamp(execute_epoch).strftime("%b %d, %Y %I:%M %p")
         cancel_url = f"switch.py?cancel_id={created_epoch}"
         pending_sched_rows.append(Markup(
             f'<tr><td>{html.escape(sched_time)}</td>'
-            f'<td>{html.escape(action_label)}</td>'
+            f'<td>{badge}{html.escape(action_label)}</td>'
             f'<td><a href="{html.escape(cancel_url)}" '
             f'class="btn btn-sm btn-outline-danger py-0">Cancel</a></td></tr>'
         ))
@@ -438,6 +507,7 @@ def _handle(environ):
 
     chart_data = []
     heater_ranges = []
+    hvac_ranges = []
     cold_ranges = []
     fan_ranges = []
     ambient_data = []
@@ -456,6 +526,7 @@ def _handle(environ):
                 cached_result = json.loads(cached[0])
                 chart_data = cached_result.get("chart_data", [])
                 heater_ranges = cached_result.get("heater_ranges", [])
+                hvac_ranges = cached_result.get("hvac_ranges", [])
                 cold_ranges = cached_result.get("cold_ranges", [])
                 fan_ranges = cached_result.get("fan_ranges", [])
                 ambient_data = cached_result.get("ambient_data", [])
@@ -466,6 +537,7 @@ def _handle(environ):
             live_result = aggregate.compute_bucketed(bucketed, chart_cutoff, chart_end_epoch)
             chart_data = live_result["chart_data"]
             heater_ranges = live_result["heater_ranges"]
+            hvac_ranges = live_result.get("hvac_ranges", [])
             cold_ranges = live_result["cold_ranges"]
             fan_ranges = live_result.get("fan_ranges", [])
             ambient_data = live_result["ambient_data"]
@@ -549,6 +621,7 @@ def _handle(environ):
         chart_title=chart_title,
         chart_data=chart_data,
         heater_ranges=heater_ranges,
+        hvac_ranges=hvac_ranges,
         cold_ranges=cold_ranges,
         fan_ranges=fan_ranges,
         ambient_data=ambient_data,
@@ -557,6 +630,14 @@ def _handle(environ):
         pending_sched_rows=pending_sched_rows,
         now_dt_min=now_dt_min,
         now_str=now_str,
+        # HVAC
+        hvac_configured=hvac_configured,
+        hvac_state=hvac_state,
+        hvac_modes=[(m, hvac.MODE_LABELS[m]) for m in hvac.ALL_MODES],
+        hvac_fans=[(f, hvac.FAN_LABELS[f]) for f in hvac.ALL_FANS],
+        hvac_temp_min_f=hvac.TEMP_MIN_F,
+        hvac_temp_max_f=hvac.TEMP_MAX_F,
+        hvac_mode_freeze=hvac.MODE_FREEZE,
     )
 
     return (
@@ -619,6 +700,29 @@ def _is_valid_month(s):
         return True
     except ValueError:
         return False
+
+
+def _hvac_sched_label(params_json):
+    """Render an HVAC schedule's params JSON as a human-readable string."""
+    if not params_json:
+        return "Set"
+    try:
+        p = json.loads(params_json)
+    except (ValueError, TypeError):
+        return "Set"
+    if p.get("mode") == hvac.MODE_FREEZE:
+        return hvac.MODE_LABELS[hvac.MODE_FREEZE]
+    parts = []
+    if p.get("power") is False:
+        parts.append("Off")
+    elif p.get("power") is True or p.get("mode"):
+        if p.get("mode"):
+            parts.append(hvac.MODE_LABELS.get(p["mode"], p["mode"]))
+        if p.get("target_f") is not None:
+            parts.append(f"{p['target_f']:.0f}°F")
+        if p.get("fan_speed") and p["fan_speed"] != "auto":
+            parts.append(f"fan {hvac.FAN_LABELS.get(p['fan_speed'], p['fan_speed']).lower()}")
+    return " · ".join(parts) if parts else "Set"
 
 
 if __name__ == "__main__":

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,84 @@
 </div>
 
 <div class="card mb-3">
+<div class="card-header {% if hvac_state and hvac_state.reported and hvac_state.reported.power %}text-bg-info{% else %}text-bg-secondary{% endif %}">
+  <h4>Hangar HVAC</h4>
+</div>
+<div class="card-body">
+{% if not hvac_configured %}
+  <p class="mb-1">Not configured.</p>
+  <p class="small text-muted mb-0">Pair the Midea WiFi dongle via NetHome Plus on your phone, then run <code>python3 setup_hvac.py</code> on the Pi.</p>
+{% elif not hvac_state or not hvac_state.reported %}
+  <p class="text-danger mb-0">HVAC dongle unreachable. Check power and network.</p>
+{% else %}
+  {% set r = hvac_state.reported %}
+  <h5 class="card-title">
+    Status: <b>{{ "ON" if r.power else "OFF" }}</b>
+    {% if r.power %} &middot; Mode: <b>{{ r.mode|capitalize }}</b>
+    {% if r.target_f is not none %} &middot; Target: <b>{{ "%.0f"|format(r.target_f) }}&deg;F / {{ "%.1f"|format(r.target_c) }}&deg;C</b>{% endif %}
+    {% endif %}
+  </h5>
+  {% if r.indoor_f is not none %}
+  <p class="mb-1 small">Indoor unit thermistor: <b>{{ "%.1f"|format(r.indoor_f) }}&deg;F / {{ "%.1f"|format(r.indoor_c) }}&deg;C</b></p>
+  {% endif %}
+  {% if hvac_state.diverged and hvac_state.commanded %}
+  {% set c = hvac_state.commanded %}
+  <p class="mb-1 small text-warning">
+    <strong>Last commanded:</strong>
+    {% if c.power %}{{ c.mode|capitalize }}{% if c.target_f is not none %} {{ "%.0f"|format(c.target_f) }}&deg;F{% endif %}, fan {{ c.fan_speed }}{% else %}OFF{% endif %}
+    &mdash; physical remote may have been used.
+  </p>
+  {% endif %}
+  {% if hvac_state.stale %}
+  <p class="mb-1 small text-warning">Stale: dongle last reachable {{ hvac_state.age_secs }}s ago.</p>
+  {% endif %}
+
+  <form action="switch.py" method="GET" class="row g-2 align-items-end mt-2">
+    <input type="hidden" name="hvac_apply" value="1">
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Power</label>
+      <select name="hvac_power" class="form-select form-select-sm">
+        <option value="1"{% if r.power %} selected{% endif %}>On</option>
+        <option value="0"{% if not r.power %} selected{% endif %}>Off</option>
+      </select>
+    </div>
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Mode</label>
+      <select name="hvac_mode" class="form-select form-select-sm">
+        {% for val, label in hvac_modes %}{% if val != hvac_mode_freeze %}
+        <option value="{{ val }}"{% if r.mode == val %} selected{% endif %}>{{ label }}</option>
+        {% endif %}{% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Target &deg;F</label>
+      <input type="number" name="hvac_target_f" class="form-control form-control-sm"
+             min="{{ hvac_temp_min_f }}" max="{{ hvac_temp_max_f }}" step="1"
+             value="{{ "%.0f"|format(r.target_f) if r.target_f is not none else 70 }}" style="width:5em">
+    </div>
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Fan</label>
+      <select name="hvac_fan_speed" class="form-select form-select-sm">
+        {% for val, label in hvac_fans %}
+        <option value="{{ val }}"{% if r.fan_speed == val %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary btn-sm">Apply</button>
+    </div>
+  </form>
+
+  <form action="switch.py" method="GET" class="d-inline">
+    <input type="hidden" name="hvac_apply" value="1">
+    <input type="hidden" name="hvac_mode" value="{{ hvac_mode_freeze }}">
+    <button type="submit" class="btn btn-outline-info btn-sm mt-2">Freeze Prevention preset</button>
+  </form>
+{% endif %}
+</div>
+</div>
+
+<div class="card mb-3">
 <div class="card-header {{ fan_header_class }}">
   <h4>Exhaust Fan</h4>
 </div>
@@ -66,6 +144,7 @@
     <a href="switch.py?range=7d" class="btn btn-sm {{ 'btn-primary' if range == '7d' else 'btn-outline-primary' }}">7 Days</a>
     <a href="switch.py?range=30d" class="btn btn-sm {{ 'btn-primary' if range == '30d' else 'btn-outline-primary' }}">30 Days</a>
     <span class="ms-3 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(220,53,69,0.3);vertical-align:middle"></span> Heater on</span>
+    <span class="ms-2 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(168,85,247,0.25);vertical-align:middle"></span> HVAC on</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(13,110,253,0.3);vertical-align:middle"></span> Fan on</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(255,152,0,0.3);vertical-align:middle"></span> &le; 48&deg;F</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:20px;border-top:2px solid rgb(34,197,94);vertical-align:middle"></span> {{ ambient_label }}</span>
@@ -95,22 +174,77 @@
 <div class="card-header"><h5 class="mb-0">Schedule</h5></div>
 <div class="card-body">
 {{ sched_msg }}
-<form action="switch.py" method="GET" class="row g-2 align-items-end">
+<form action="switch.py" method="GET" class="row g-2 align-items-end" id="schedForm">
   <div class="col-auto">
     <label for="sched_dt" class="form-label mb-0 small">Date &amp; Time</label>
     <input type="datetime-local" id="sched_dt" name="sched_dt" class="form-control form-control-sm" required min="{{ now_dt_min }}">
   </div>
   <div class="col-auto">
+    <label for="sched_device" class="form-label mb-0 small">Device</label>
+    <select id="sched_device" name="sched_device" class="form-select form-select-sm" onchange="schedToggle()">
+      <option value="heater">Heater</option>
+      {% if hvac_configured %}<option value="hvac">HVAC</option>{% endif %}
+    </select>
+  </div>
+  <div class="col-auto sched-heater">
     <label for="sched_action" class="form-label mb-0 small">Action</label>
     <select id="sched_action" name="sched_action" class="form-select form-select-sm">
       <option value="1">Turn ON</option>
       <option value="0">Turn OFF</option>
     </select>
   </div>
+  {% if hvac_configured %}
+  <div class="col-auto sched-hvac" style="display:none">
+    <label for="sched_hvac_mode" class="form-label mb-0 small">Mode</label>
+    <select id="sched_hvac_mode" name="sched_hvac_mode" class="form-select form-select-sm" onchange="schedHvacModeToggle()">
+      {% for val, label in hvac_modes %}
+      <option value="{{ val }}"{% if val == 'heat' %} selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-auto sched-hvac sched-hvac-temp" style="display:none">
+    <label for="sched_hvac_target_f" class="form-label mb-0 small">Target &deg;F</label>
+    <input type="number" id="sched_hvac_target_f" name="sched_hvac_target_f" class="form-control form-control-sm"
+           min="{{ hvac_temp_min_f }}" max="{{ hvac_temp_max_f }}" step="1" value="70" style="width:5em">
+  </div>
+  <div class="col-auto sched-hvac sched-hvac-fan" style="display:none">
+    <label for="sched_hvac_fan_speed" class="form-label mb-0 small">Fan</label>
+    <select id="sched_hvac_fan_speed" name="sched_hvac_fan_speed" class="form-select form-select-sm">
+      {% for val, label in hvac_fans %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+    </select>
+  </div>
+  <div class="col-auto sched-hvac sched-hvac-power" style="display:none">
+    <label for="sched_hvac_power" class="form-label mb-0 small">Power</label>
+    <select id="sched_hvac_power" name="sched_hvac_power" class="form-select form-select-sm">
+      <option value="1" selected>On</option>
+      <option value="0">Off</option>
+    </select>
+  </div>
+  {% endif %}
   <div class="col-auto">
     <button type="submit" class="btn btn-primary btn-sm">Schedule</button>
   </div>
 </form>
+<script>
+function schedToggle() {
+  var device = document.getElementById('sched_device').value;
+  document.querySelectorAll('.sched-heater').forEach(function(el) { el.style.display = device === 'heater' ? '' : 'none'; });
+  document.querySelectorAll('.sched-hvac').forEach(function(el) { el.style.display = device === 'hvac' ? '' : 'none'; });
+  if (device === 'hvac') schedHvacModeToggle();
+}
+function schedHvacModeToggle() {
+  var modeSel = document.getElementById('sched_hvac_mode');
+  if (!modeSel) return;
+  var mode = modeSel.value;
+  // Freeze Prevention preset = no extra fields
+  var isFreeze = mode === 'freeze';
+  ['sched-hvac-temp', 'sched-hvac-fan', 'sched-hvac-power'].forEach(function(cls) {
+    document.querySelectorAll('.' + cls).forEach(function(el) {
+      el.style.display = isFreeze ? 'none' : '';
+    });
+  });
+}
+</script>
 {% if pending_sched_rows %}
 <hr>
 <h6>Pending</h6>
@@ -131,6 +265,7 @@
 <script>
 var data = {{ chart_data | tojson }};
 var heaterRanges = {{ heater_ranges | tojson }};
+var hvacRanges = {{ hvac_ranges | tojson }};
 var coldRanges = {{ cold_ranges | tojson }};
 var fanRanges = {{ fan_ranges | tojson }};
 var ambientData = {{ ambient_data | tojson }};
@@ -155,6 +290,7 @@ function buildRangeData(data, ranges) {
   return out;
 }
 var heaterData = buildRangeData(data, heaterRanges);
+var hvacData = buildRangeData(data, hvacRanges);
 var fanData = buildRangeData(data, fanRanges);
 var annotations = {};
 coldRanges.forEach(function(r, i) {
@@ -190,6 +326,14 @@ if (data.length > 0) {
         data: heaterData,
         borderColor: 'transparent',
         backgroundColor: 'rgba(220, 53, 69, 0.25)',
+        fill: 'origin',
+        pointRadius: 0,
+        tension: 0.3,
+        spanGaps: false
+      }, {
+        data: hvacData,
+        borderColor: 'transparent',
+        backgroundColor: 'rgba(168, 85, 247, 0.25)',
         fill: 'origin',
         pointRadius: 0,
         tension: 0.3,


### PR DESCRIPTION
## Summary
- Adds remote control of the hangar Durastar mini-split (Midea OEM, DRAW33F2A) via the Midea US-OSK105 WiFi dongle on the LAN — independent of the existing engine-block heater and exhaust fan, all in the same web UI.
- New \`hvac.py\` wraps \`msmart-ng\` (async) into sync helpers for the WSGI app, with a 30s state cache in \`/run/heater-hvac.json\` (RAM, not SD card).
- New \`setup_hvac.py\` is a one-time pairing helper run after plugging in the dongle and pairing via the NetHome Plus phone app.

## What's new in the UI
- **Hangar HVAC card** between Heater and Fan: shows reported power/mode/target/indoor-temp, single Apply form (power/mode/target °F/fan), one-click **Freeze Prevention** preset.
- **Schedule form** gets a Device picker — schedule heater on/off OR an HVAC state change at a future time.
- **Chart** adds a purple band for HVAC activity (alongside red heater / blue fan).
- **Drift detection**: if someone uses the physical IR remote, the card surfaces both the dongle's reported state and the last-commanded state.
- **Stale state UX**: if the dongle is unreachable, last cached state is shown with a \"stale Xs\" badge instead of erroring.

## Schema changes (additive, backward-compatible)
- \`schedules\`: \`device TEXT DEFAULT 'heater'\` and \`params TEXT DEFAULT ''\`. Existing heater rows still dispatch via \`COALESCE\`.
- \`readings\`: \`ac_state INTEGER\` (0=off, 1=heat, 2=cool, 3=fan, 4=dry, 5=auto). \`aggregate.compute_bucketed\` collapses this to a binary band for the chart.
- All migrations follow the existing \`ALTER TABLE ... ADD COLUMN\` try/except pattern in \`get_db()\` / \`get_ram_db()\`. No new migration framework.

## Important caveats
- **Pair via NetHome Plus, NOT SmartHome.** SmartHome's \`get_token\` cloud endpoint is currently broken (msmart-ng issue #201). Setup script enforces \`account=\"NetHomePlus\"\`.
- **Freeze Prevention is a software preset** = Heat / 60°F / Low fan. msmart-ng does not expose Midea's true 8°C anti-freeze flag over the dongle; if that ever surfaces, swap \`hvac._resolve_freeze()\`.
- **\`pip install msmart-ng\`** is required on the Pi before \`setup_hvac.py\`. Lazy import in \`hvac.py\` means the rest of the app boots fine without it.
- **SD-card-wear principle** is now explicit in CLAUDE.md: hot-path writes (per-minute, per-request) go to \`/run\` (tmpfs); \`/var/lib/heater\` is only for weekly flush + monthly rollup + rare schedule add/cancel. The new \`/run/heater-hvac.json\` honors this.

## Files
- New: \`hvac.py\`, \`setup_hvac.py\`
- Modified: \`config.py\` (schema + queries), \`aggregate.py\` (hvac_ranges), \`log_temp.py\` (dispatch by device, log ac_state), \`switch.py\` (HVAC apply + schedule extension + render), \`templates/index.html\` (HVAC card + chart band + schedule picker), \`.env.example\`, \`README.md\`, \`CLAUDE.md\`

## Test plan
- [ ] On the Pi: \`sudo pip install msmart-ng\`
- [ ] Plug Midea US-OSK105 dongle into indoor unit's WiFi USB port
- [ ] Pair via NetHome Plus phone app (NOT SmartHome)
- [ ] \`sudo python3 /usr/lib/cgi-bin/remote-switch/setup_hvac.py\` — verify discovery succeeds, token+key are written to \`.env\`, and the verification refresh prints current state
- [ ] Reload web UI — confirm Hangar HVAC card replaces \"Not configured\" placeholder
- [ ] Apply form: change power on/off, mode (Heat / Cool / Auto), target temp, fan speed — verify the indoor unit responds
- [ ] Click Freeze Prevention preset — verify it sets Heat / 60°F / Low
- [ ] Use the physical IR remote to change something — verify the HVAC card surfaces \"Last commanded:\" line within 30s
- [ ] Schedule a future HVAC action — verify it appears in pending list with \"[HVAC]\" badge, and fires at the scheduled time
- [ ] Verify the existing engine-block heater toggle and exhaust fan auto-mode still work unchanged
- [ ] After ~24h of data: verify the purple HVAC band appears on the 7-day chart when the unit was active

## Local verification (already done)
- \`py_compile\` clean on all 6 Python files
- Jinja2 template renders in unconfigured / configured-active / diverged+stale branches
- Schema migration on a sandbox DB: fresh install creates new columns; old DB gets columns added; pre-existing schedule rows still classified as heater
- \`_hvac_sched_label()\` produces sane strings for all reasonable param shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)