### PR TITLE
feat(wifi-bridge): single-radio AP+STA bridge for Midea pairing on open hangar WiFi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Raspberry Pi airplane hangar controller. The web UI controls three independent d
 - `log_temp.py` — cron job: logs readings every minute, flushes weekly, rollup monthly
 - `hvac.py` — Hangar HVAC (Durastar/Midea mini-split) control via WiFi dongle on LAN, msmart-ng wrapper
 - `setup_hvac.py` — one-time pairing helper: discovers the dongle, fetches local token+key, writes HVAC_* keys to .env
+- `scripts/setup-wifi-bridge.sh` — optional one-shot installer for the AP+STA bridge that lets the Midea dongle pair on open hangar WiFi. See "WiFi bridge" below.
 - `templates/index.html` — Jinja2 template
 - `heater-flush.service` — systemd unit, flushes RAM DB to disk on commanded shutdown/reboot
 
@@ -52,6 +53,20 @@ Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set
 - `LOCATION` in `.env` can be an ICAO code (e.g. `KLMO`); lat/lon resolved via OurAirports CSV geocoding on first run.
 - mod_wsgi daemon mode auto-reloads when `switch.py` changes — `git pull` is sufficient, no Apache restart needed.
 - All schema additions use `ALTER TABLE ... ADD COLUMN` wrapped in try/except in `get_db()` / `get_ram_db()`. Don't introduce a separate migration system.
+
+## WiFi bridge (`scripts/setup-wifi-bridge.sh`)
+- **Purpose: pairing only.** The Midea dongle's pairing app (NetHome Plus) refuses to pair against an open SSID. Many hangar WiFi networks are open. The bridge lets the Pi broadcast its own WPA2 SSID for the dongle to live on, while the Pi stays a client on the open hangar WiFi and NATs the dongle's traffic out.
+- **The dongle's permanent home is the Pi's AP**, not the hangar WiFi. After the one-time cloud handshake (driven by `setup_hvac.py`), the dongle never needs the internet again — `msmart-ng` reaches it locally on the AP subnet at TCP/6444.
+- **Single-radio AP+STA shares one channel.** `AP_CHAN` in the install script must match the hangar WiFi's current channel; hostapd refuses to start on a mismatch with "Could not set channel". If the hangar router roams channels, pin it.
+- **Files written by the script:**
+  - `/etc/systemd/system/uap0.service` — creates the `uap0` virtual __ap interface on `wlan0`, gives it `192.168.50.1/24`
+  - `/etc/hostapd/hostapd.conf` — WPA2-PSK on `uap0`, channel hard-coded
+  - `/etc/dnsmasq.d/uap0.conf` — DHCP `192.168.50.50–.150` on `uap0` only (`bind-interfaces` keeps it off `wlan0`)
+  - `/etc/NetworkManager/conf.d/uap0-unmanaged.conf` (Bookworm) or `denyinterfaces uap0` in `/etc/dhcpcd.conf` (Bullseye) — keeps the system network manager from fighting hostapd over `uap0`
+  - iptables MASQUERADE on `wlan0` + FORWARD rules, persisted via `iptables-persistent` / `netfilter-persistent`
+- **Single dongle, single client.** Don't optimize this for many clients — there's exactly one (the Midea). Throughput is irrelevant; reliability over months is what matters.
+- **BCM43438 AP+STA can wedge.** Symptom: dongle drops off, hostapd looks healthy but new associations fail. Recovery: `sudo systemctl restart hostapd`. If this becomes routine, the answer is a USB WiFi dongle (e.g. TL-WN725N) so AP and STA live on separate radios — not a watchdog. A watchdog is fine as a stopgap but masks the real issue.
+- **Don't add a second AP for clients.** This bridge exists to pair an IoT device, not to serve users. Adding clients re-introduces all the throughput and channel-sharing issues we accept here.
 
 ## HVAC module specifics (`hvac.py`)
 - **Source of truth for the hangar climate.** All Durastar/Midea code lives here; nothing else imports `msmart`.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,50 @@ The web UI includes a one-shot scheduler that can act on either the engine-block
 
 ---
 
+## Optional: WiFi Bridge (for HVAC pairing on open WiFi)
+
+The Midea WiFi dongle's pairing app (NetHome Plus) requires a WPA2-protected SSID. Hangar WiFi is often open or guest-only, which the app refuses to pair against. Skip this section if your hangar WiFi already has a password.
+
+The fix is to run the Pi as a single-radio AP+STA bridge: it stays a client on the open hangar WiFi (`wlan0`) while broadcasting its own WPA2-protected SSID (`uap0`) on the same chip. The Midea dongle pairs to the Pi's SSID, NATs out through the hangar WiFi for the one-time cloud handshake, and lives on the Pi's AP subnet permanently. The Pi reaches the dongle directly across the AP subnet, so `setup_hvac.py` and `msmart-ng` work without any further routing.
+
+### One-shot setup
+```bash
+sudo AP_PASS=ChangeMeStrong AP_CHAN=<channel> /usr/lib/cgi-bin/remote-switch/scripts/setup-wifi-bridge.sh
+sudo reboot
+```
+
+`AP_CHAN` **must match the hangar WiFi's current channel** — single-radio AP+STA shares one channel, and hostapd will refuse to start on a mismatch. Find it once with:
+
+```bash
+iw dev wlan0 link | grep freq
+# 2412->1, 2437->6, 2462->11, etc. (5 MHz steps from 2412)
+```
+
+Optional overrides via environment variables (defaults shown):
+- `AP_SSID=hvac-pair`
+- `AP_NET=192.168.50` (Pi gets `.1`, dongle DHCPs `.50`–`.150`)
+
+### After reboot
+1. On your phone, join `hvac-pair` (the Pi's AP). Open NetHome Plus and pair the dongle, pointing it at `hvac-pair`.
+2. Find the dongle's IP on the Pi's AP subnet:
+   ```bash
+   sudo cat /var/lib/misc/dnsmasq.leases
+   ```
+3. Run `setup_hvac.py` per the [Hangar HVAC](#optional-hangar-hvac-durastar-mini-split) section below.
+
+The dongle stays on `hvac-pair` forever after this. The Midea cloud is only needed during pairing; once the local token+key are written to `.env`, you can firewall the dongle's outbound internet without losing functionality.
+
+### Caveats on the Pi Zero W's built-in radio
+The BCM43438's AP+STA mode is functional but not bulletproof — `uap0` can occasionally wedge after days/weeks and need `sudo systemctl restart hostapd`. For one low-traffic client (the Midea dongle) this is rarely a problem. If it bites you often, plug in a USB WiFi dongle (TP-Link TL-WN725N is small and well-supported on hostapd) and rerun the setup script with `wlan1` for one of the roles — moving AP and STA onto separate radios eliminates the time-slicing and channel-sharing constraints entirely.
+
+### Troubleshooting
+- **`hostapd` fails with "Could not set channel".** `wlan0` is on a different channel than `AP_CHAN`. Check current channel with `iw dev wlan0 link | grep freq`, edit `channel=` in `/etc/hostapd/hostapd.conf`, `sudo systemctl restart hostapd`. If the hangar router roams channels, pin it in the router's admin page.
+- **`uap0` doesn't appear after reboot.** Check `journalctl -u uap0` — usually means `wlan0` wasn't ready yet. `sudo systemctl restart uap0 hostapd dnsmasq` and it should come up.
+- **Midea dongle pairs but the Pi can't reach it.** Confirm the dongle got a lease (`/var/lib/misc/dnsmasq.leases`) and that you can `ping <dongle_ip>` from the Pi. If pings fail, hostapd is up but the dongle didn't actually associate — re-run the NetHome Plus pairing.
+- **Internet works on the Pi but not from the dongle.** NAT rule didn't persist. `sudo iptables -t nat -L POSTROUTING -v` should show a MASQUERADE rule on `wlan0`; if missing, re-run the setup script.
+
+---
+
 ## Optional: Hangar HVAC (Durastar mini-split)
 
 The web UI can also control a hangar Durastar/Midea mini-split (and any other Midea-OEM unit — Pioneer, MrCool, Senville, Comfee, etc.) over the LAN via the Midea WiFi dongle. This is independent of the engine-block heater described above — the heater stays on its own GPIO relay; the HVAC is reached over the LAN through the [`msmart-ng`](https://github.com/mill1000/midea-msmart) Python library.

--- a/scripts/setup-wifi-bridge.sh
+++ b/scripts/setup-wifi-bridge.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Configure the Pi as a single-radio AP+STA WiFi bridge.
+#
+# Why: the Midea WiFi dongle's pairing app (NetHome Plus) requires a
+# WPA2-protected SSID, but the hangar WiFi may be open. This script runs the
+# Pi as a client on the hangar WiFi (wlan0) while broadcasting a
+# WPA2-protected SSID (uap0) on the same radio. The Midea dongle pairs to
+# uap0, NATs out through wlan0 for the one-time cloud handshake, then lives
+# on uap0 permanently. The Pi reaches it directly across the AP subnet.
+#
+# Constraint: single-radio AP+STA must share a channel. AP_CHAN must match
+# the hangar WiFi's current channel or hostapd will fail to start.
+#
+# Usage:
+#   sudo AP_PASS=<pw> AP_CHAN=<n> ./scripts/setup-wifi-bridge.sh
+#
+# Run on the Pi after wlan0 is already associated to the hangar WiFi.
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Run as root: sudo $0" >&2
+  exit 1
+fi
+
+AP_SSID="${AP_SSID:-hvac-pair}"
+AP_PASS="${AP_PASS:-}"
+AP_CHAN="${AP_CHAN:-}"
+AP_NET="${AP_NET:-192.168.50}"
+
+if [ ${#AP_PASS} -lt 8 ]; then
+  echo "Set AP_PASS to a string of 8+ chars (WPA2 minimum)." >&2
+  echo "Example: sudo AP_PASS=mypassword AP_CHAN=3 $0" >&2
+  exit 1
+fi
+
+if [ -z "$AP_CHAN" ]; then
+  echo "AP_CHAN must match the hangar WiFi's channel." >&2
+  echo "Find it with: iw dev wlan0 link | grep freq" >&2
+  echo "  2412->1, 2417->2, 2422->3, 2427->4, 2432->5, 2437->6," >&2
+  echo "  2442->7, 2447->8, 2452->9, 2457->10, 2462->11" >&2
+  exit 1
+fi
+
+echo "Installing packages..."
+apt update
+DEBIAN_FRONTEND=noninteractive apt install -y hostapd dnsmasq iptables-persistent
+systemctl unmask hostapd
+systemctl stop hostapd dnsmasq || true
+
+echo "Writing /etc/systemd/system/uap0.service..."
+cat > /etc/systemd/system/uap0.service <<EOF
+[Unit]
+Description=Create uap0 virtual AP interface
+After=sys-subsystem-net-devices-wlan0.device
+Wants=sys-subsystem-net-devices-wlan0.device
+Before=hostapd.service dnsmasq.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/iw dev wlan0 interface add uap0 type __ap
+ExecStart=/sbin/ip addr add ${AP_NET}.1/24 dev uap0
+ExecStart=/sbin/ip link set uap0 up
+ExecStop=/sbin/iw dev uap0 del
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Writing /etc/hostapd/hostapd.conf..."
+cat > /etc/hostapd/hostapd.conf <<EOF
+interface=uap0
+driver=nl80211
+ssid=${AP_SSID}
+hw_mode=g
+channel=${AP_CHAN}
+ieee80211n=1
+wmm_enabled=1
+auth_algs=1
+wpa=2
+wpa_key_mgmt=WPA-PSK
+rsn_pairwise=CCMP
+wpa_passphrase=${AP_PASS}
+EOF
+sed -i 's|^#\?DAEMON_CONF=.*|DAEMON_CONF="/etc/hostapd/hostapd.conf"|' /etc/default/hostapd
+
+echo "Writing /etc/dnsmasq.d/uap0.conf..."
+cat > /etc/dnsmasq.d/uap0.conf <<EOF
+interface=uap0
+bind-interfaces
+dhcp-range=${AP_NET}.50,${AP_NET}.150,255.255.255.0,12h
+dhcp-option=3,${AP_NET}.1
+dhcp-option=6,1.1.1.1,8.8.8.8
+EOF
+
+if systemctl is-active --quiet NetworkManager; then
+  echo "Telling NetworkManager to leave uap0 alone..."
+  cat > /etc/NetworkManager/conf.d/uap0-unmanaged.conf <<EOF
+[keyfile]
+unmanaged-devices=interface-name:uap0
+EOF
+  systemctl reload NetworkManager
+fi
+
+if systemctl is-active --quiet dhcpcd; then
+  if ! grep -q "denyinterfaces uap0" /etc/dhcpcd.conf; then
+    echo "Telling dhcpcd to leave uap0 alone..."
+    echo "denyinterfaces uap0" >> /etc/dhcpcd.conf
+  fi
+fi
+
+echo "Enabling IP forwarding and NAT..."
+sed -i 's|^#net.ipv4.ip_forward=1|net.ipv4.ip_forward=1|' /etc/sysctl.conf
+sysctl -w net.ipv4.ip_forward=1 >/dev/null
+
+iptables -t nat -C POSTROUTING -o wlan0 -j MASQUERADE 2>/dev/null \
+  || iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
+iptables -C FORWARD -i wlan0 -o uap0 -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
+  || iptables -A FORWARD -i wlan0 -o uap0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+iptables -C FORWARD -i uap0 -o wlan0 -j ACCEPT 2>/dev/null \
+  || iptables -A FORWARD -i uap0 -o wlan0 -j ACCEPT
+netfilter-persistent save >/dev/null
+
+echo "Enabling services..."
+systemctl daemon-reload
+systemctl enable uap0 hostapd dnsmasq
+
+cat <<EOF
+
+Setup complete. Reboot to bring up the bridge:
+  sudo reboot
+
+After reboot, verify:
+  ip addr show uap0                # should show ${AP_NET}.1
+  iw dev uap0 info                 # type AP
+  systemctl status hostapd dnsmasq # both active
+  iw dev wlan0 link                # still associated to hangar WiFi
+  ping -c2 1.1.1.1                 # internet works
+
+SSID: ${AP_SSID}  channel: ${AP_CHAN}  subnet: ${AP_NET}.0/24
+EOF


### PR DESCRIPTION
## Summary

The Midea NetHome Plus app refuses to pair against an open SSID, which blocks HVAC setup on hangars whose WiFi has no password. This PR adds a one-shot installer that turns the Pi into a WPA2-protected AP for the dongle to live on, while `wlan0` stays a client on the open upstream WiFi. The dongle pairs to the Pi's SSID, NATs out for the one-time Midea cloud handshake, and lives on the Pi's AP subnet permanently.

- **`scripts/setup-wifi-bridge.sh`** — installer: hostapd + dnsmasq + `uap0` virtual `__ap` interface + iptables MASQUERADE. Hands `uap0` off from NetworkManager (Bookworm) or dhcpcd (Bullseye) so the system network manager doesn't fight hostapd. `AP_CHAN` env var must match the upstream channel — single-radio AP+STA shares a channel.
- **README.md** — new "Optional: WiFi Bridge" section before the HVAC section, since the bridge is a prerequisite for HVAC pairing on open WiFi. Includes the channel-discovery one-liner, post-reboot verification steps, and the BCM43438 caveat.
- **CLAUDE.md** — bridge architecture notes: files written, the "dongle's permanent home is the Pi's AP" invariant, BCM43438 AP+STA wedge recovery, and a note that chronic flakiness is fixed by a second radio (USB dongle), not a watchdog.

## Test plan

- [x] Script syntax check (`bash -n`)
- [ ] Run installer on the Pi Zero W with hangar WiFi already configured
- [ ] After reboot: `ip addr show uap0` shows `192.168.50.1`, `iw dev uap0 info` shows type AP, `iw dev wlan0 link` still associated to hangar WiFi, `ping -c2 1.1.1.1` works
- [ ] Pair the Midea dongle via NetHome Plus pointed at `hvac-pair`; confirm a DHCP lease in `/var/lib/misc/dnsmasq.leases`
- [ ] Run `setup_hvac.py`, confirm it discovers the dongle on the AP subnet and writes `HVAC_*` keys to `.env`
- [ ] Confirm HVAC card in web UI controls the unit normally

https://claude.ai/code/session_019mCuNMeQuX7dE1Fp6YuKNY

---
_Generated by [Claude Code](https://claude.ai/code/session_019mCuNMeQuX7dE1Fp6YuKNY)_