### PR TITLE
fix(hvac): remove FP from web UI — it's IR-only on Durastar DRAW33F2A

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ When adding a new persistent thing, ask: how often is it written? If more than w
 ## Schedule schema (extended for HVAC)
 The `schedules` table has two columns added on top of the original heater schema:
 - `device TEXT DEFAULT 'heater'` — `'heater'` or `'hvac'`
-- `params TEXT DEFAULT ''` — JSON for HVAC schedules: `{power, mode, target_f, fan_speed}` or `{mode: "freeze"}`
-Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set"` and read everything from `params`. `log_temp.py do_log()` dispatches by device.
+- `params TEXT DEFAULT ''` — JSON for HVAC schedules: `{power, mode, target_f, fan_speed}`
+Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set"` and read everything from `params`. `log_temp.py do_log()` dispatches by device. Pre-2026-05 rows may exist with `{mode: "freeze"}` from the now-removed MODE_FREEZE feature — `set_state()` filters unknown modes through `mode in msmart_modes`, so those legacy schedules silently no-op when due (the row is still deleted from the table).
 
 ## Readings columns added for HVAC
 `readings.ac_state INTEGER` — 0=off, 1=heat, 2=cool, 3=fan, 4=dry, 5=auto. Logged every minute by cron via `hvac.state_for_log()`. `aggregate.compute_bucketed` collapses this to a binary "any non-off" band rendered in purple on the chart.
@@ -79,8 +79,8 @@ Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set
   ```
   TTL is `hvac.CACHE_TTL_SECS = 30`. `get_state()` returns `{reported, commanded, stale, age_secs, diverged}`. On dongle error, returns the stale cached view with `stale=True` instead of raising.
 - **Two-way visibility:** `set_state()` writes both `reported` (post-apply) and `commanded` (what we asked for). UI surfaces commanded only when `_diverged()` returns True (catches drift if someone uses the physical IR remote — common in this hangar).
-- **Stable mode/fan tokens** (used in `.env`, schedule `params` JSON, `?hvac_*=` query strings, and chart logic): `MODE_AUTO/COOL/DRY/HEAT/FAN/FREEZE` and `FAN_AUTO/LOW/MED/HIGH`. Don't add or rename without checking all four call sites.
-- **Freeze Prevention is the unit's REAL flag.** `MODE_FREEZE` maps to `dev.freeze_protection = True` over the LAN protocol — the same feature the IR remote drives, the unit displays "FP", and the firmware holds a minimum heat output (~8°C/46°F) internally. Capability flags (`dev.supports_freeze_protection`) are unreliable on some units (msmart-ng issue #76); we always send the SetState bit regardless. Setting any other explicit `mode` automatically clears the freeze flag — exit FP whenever the user picks a different mode. The state byte is `payload[21] bit 0x80` in msmart-ng's SetState/StateResponse if you ever need to debug at the wire level.
+- **Stable mode/fan tokens** (used in `.env`, schedule `params` JSON, `?hvac_*=` query strings, and chart logic): `MODE_AUTO/COOL/DRY/HEAT/FAN` and `FAN_AUTO/LOW/MED/HIGH`. Don't add or rename without checking all four call sites.
+- **Why FP is IR-only on this Durastar.** This is the most important non-obvious thing about the HVAC module. The IR remote's "down twice from 60°F" sequence engages a hidden internal regulator that holds the room at ~46°F minimum (the unit displays "FP", and the regulator IS doing real work — verified by months of probe data showing a 46°F floor against 32°F ambient). The msmart `freeze_protection` SetState bit (`payload[21] & 0x80`) is purely **cosmetic** on this unit — it lights the FP icon but does NOT engage the 46°F regulator. We confirmed this on 2026-05-05 by byte-for-byte diffing the StateResponse after IR-FP and after `dev.freeze_protection=True` via msmart: identical wire bytes, but only the IR path produces real freeze prevention. The dongle reports `min_target_temperature: 16` (60.8°F) and clamps any LAN target below that, so we can't even reach 46°F by setting a low target. Implications: (1) the web UI does NOT expose Freeze Prevention — it would be misleading; (2) `set_state()` never touches `dev.freeze_protection`; (3) **any LAN `apply()` while IR-FP is active will likely cancel the regulator** — the UI shows a warning banner when `freeze_protection: True` is reported. During winter, treat the HVAC card as read-only.
 - **`state_for_log()`** returns `None` (not 0) when not configured / unreachable, so the `readings.ac_state` column stays NULL rather than misreporting "off". Aggregations treat `None` as "no data, don't render".
 
 ## msmart-ng API surface (verified 2025.12.0)
@@ -100,7 +100,7 @@ The wrappers were verified against msmart-ng 2025.12.0. If you upgrade, watch th
 ## URL surface
 - Heater: `?state=0|1`
 - Fan: `?fan_state=0|1`, `?fan_mode=auto`
-- HVAC immediate apply: `?hvac_apply=1` plus `&hvac_power=0|1&hvac_mode=…&hvac_target_f=…&hvac_fan_speed=…`. Special case: `&hvac_mode=freeze` triggers the Freeze Prevention preset and ignores the other args.
+- HVAC immediate apply: `?hvac_apply=1` plus `&hvac_power=0|1&hvac_mode=…&hvac_target_f=…&hvac_fan_speed=…`. (Freeze Prevention is not exposed — see "Why FP is IR-only" above.)
 - Schedule add: `?sched_dt=YYYY-MM-DDTHH:MM&sched_device=heater|hvac` plus device-specific params (`sched_action` for heater; `sched_hvac_mode/target_f/fan_speed/power` for HVAC).
 - Schedule cancel: `?cancel_id=<created_epoch>`.
 - Chart range: `?range=7d|30d|YYYY-MM`.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Requires [`msmtp`](https://marlam.de/msmtp/) to be installed and configured. The
 
 ## Scheduling
 
-The web UI includes a one-shot scheduler that can act on either the engine-block heater (turn on/off) or the hangar HVAC (mode + target temp + fan, including a one-click Freeze Prevention preset). Schedules are stored in the database and executed by the every-minute cron job — no additional setup needed. Schedules survive reboots.
+The web UI includes a one-shot scheduler that can act on either the engine-block heater (turn on/off) or the hangar HVAC (mode + target temp + fan). Schedules are stored in the database and executed by the every-minute cron job — no additional setup needed. Schedules survive reboots.
 
 ---
 
@@ -255,7 +255,7 @@ The web UI can also control a hangar Durastar/Midea mini-split (and any other Mi
 ### How it works
 - A small WiFi dongle plugs into a USB-shaped port inside the indoor unit's front panel and bridges Midea's serial protocol to a TCP service on port 6444 of the dongle's LAN IP.
 - After a one-time pairing through Midea's cloud, the Pi extracts a local `token` + `key` and from then on talks to the dongle directly on the LAN — no cloud roundtrip per command, and you can firewall the dongle off the internet.
-- The web UI's HVAC card lets you set power, mode (Heat / Cool / Auto / Dry / Fan), target temperature in °F, and fan speed. A one-click "Freeze Prevention preset" button sends Heat / 60°F / Low fan — useful for "keep the hangar from freezing" scenarios.
+- The web UI's HVAC card lets you set power, mode (Heat / Cool / Auto / Dry / Fan), target temperature in °F, and fan speed. **Freeze Prevention is intentionally not exposed in the web UI** — see [Why FP is IR-only](#why-fp-is-ir-only) below.
 - The scheduler accepts HVAC actions alongside heater actions; same `execute_epoch <= now` cron-driven dispatch.
 - The dongle is polled at most once every 30 seconds (cached in `/run/heater-hvac.json`); page loads never block on the network. If the dongle is unreachable, the UI shows the last-known state with a "stale Xs" badge instead of erroring.
 - HVAC activity is logged into `readings.ac_state` every minute and rendered on the chart as a purple band, so you can see HVAC + heater + fan + ambient temperature on one timeline.
@@ -290,8 +290,15 @@ HVAC_TOKEN=<long hex string>
 HVAC_KEY=<long hex string>
 ```
 
-### What is "Freeze Prevention"?
-The unit's real Freeze Protection flag — the same feature the IR remote drives. When active the indoor unit displays "FP" and the firmware holds a minimum heat output (~8°C / 46°F) internally; you don't need to (and can't) set a target temp or fan speed. Picking any other mode in the web UI exits the flag automatically. Ideal for "keep the hangar above freezing all winter without thinking about it."
+### Why FP is IR-only
+On the Durastar DRAW33F2A (and likely other Midea-OEM units), the IR remote's "down twice from 60°F" sequence engages an internal freeze-prevention regulator that holds the room at ~46°F minimum. The unit displays "FP" while it's active. **This regulator lives in a register the LAN protocol cannot read or write.** The msmart-ng `freeze_protection` flag we can drive over the dongle (`payload[21] & 0x80` in the SetState frame) only lights the FP icon — it does not engage the regulator. Verified by byte-for-byte StateResponse comparison plus months of probe data showing a real 46°F floor when IR-FP was active.
+
+Two consequences for this app:
+
+1. **The web UI does not expose Freeze Prevention.** A button that only flips the cosmetic flag would be misleading.
+2. **Don't touch the HVAC card while the unit is in IR-FP** (the UI shows a banner when this is the case). Any LAN `apply()` we send is a full SetState frame and will likely cancel the IR-set regulator. During winter, treat the HVAC card as read-only and use the IR remote for any climate changes.
+
+To engage real FP on this unit: with the unit on, press temperature-down on the IR remote until you reach 60°F, then press down twice more. The display shows "FP" and the unit will hold ~46°F minimum until you exit FP via the IR remote.
 
 ### Drift detection
 If someone uses the physical IR remote while you're away, the dongle's reported state diverges from what the web UI last commanded. When this happens, the HVAC card surfaces both the **Reported** state (what the unit is doing now) and **Last commanded** (what was last sent from the web), so you can see at a glance that the physical remote was used.

--- a/hvac.py
+++ b/hvac.py
@@ -39,9 +39,8 @@ MODE_COOL   = "cool"
 MODE_DRY    = "dry"
 MODE_HEAT   = "heat"
 MODE_FAN    = "fan"
-MODE_FREEZE = "freeze"  # maps to dev.freeze_protection (Midea's real "FP" flag)
 
-ALL_MODES = [MODE_AUTO, MODE_COOL, MODE_DRY, MODE_HEAT, MODE_FAN, MODE_FREEZE]
+ALL_MODES = [MODE_AUTO, MODE_COOL, MODE_DRY, MODE_HEAT, MODE_FAN]
 
 MODE_LABELS = {
     MODE_AUTO:   "Auto",
@@ -49,8 +48,17 @@ MODE_LABELS = {
     MODE_DRY:    "Dry",
     MODE_HEAT:   "Heat",
     MODE_FAN:    "Fan only",
-    MODE_FREEZE: "Freeze Prevention",
 }
+
+# Freeze Prevention is intentionally NOT in ALL_MODES. On the Durastar DRAW33F2A
+# the IR remote's "down twice from 60°F" sequence engages a hidden internal
+# regulator that holds the room at ~46°F — and that regulator lives in a register
+# the LAN protocol cannot read or write. The msmart `freeze_protection` SetState
+# bit is purely cosmetic on this unit (icon flag only). We therefore never set
+# it, and we don't expose FP in the web UI. The dongle still reports the flag in
+# `freeze_protection` so the UI can surface "FP icon active" if it wants to —
+# but driving it from here would just disturb the IR-set regulator. See
+# CLAUDE.md "Why FP is IR-only" for the diagnostic story.
 
 FAN_AUTO = "auto"
 FAN_LOW  = "low"
@@ -139,30 +147,25 @@ def _run_async(coro):
 def _device_to_dict(dev):
     """Translate an msmart-ng AirConditioner's live attributes to a plain dict.
 
-    When the unit's real Freeze Protection flag (`dev.freeze_protection`, exposed
-    over the LAN protocol since msmart-ng 2023.x) is set, surface MODE_FREEZE as
-    the effective mode regardless of the underlying operational_mode the firmware
-    reports — the unit displays "FP" in this state and the UI should match.
+    `freeze_protection` is reported as a separate boolean (the unit's FP icon
+    state) but is NOT surfaced as a `mode` value. See the comment at the top of
+    this module for why FP is IR-only on this Durastar.
     """
     inv_modes = {v: k for k, v in _msmart_modes().items()}
     inv_fans  = {v: k for k, v in _msmart_fans().items()}
 
     target_c = float(dev.target_temperature) if dev.target_temperature is not None else None
     indoor_c = float(dev.indoor_temperature) if dev.indoor_temperature is not None else None
-    freeze_on = bool(getattr(dev, "freeze_protection", False))
-
-    op_mode = inv_modes.get(dev.operational_mode, str(dev.operational_mode))
-    effective_mode = MODE_FREEZE if freeze_on else op_mode
 
     return {
         "power":             bool(dev.power_state),
-        "mode":              effective_mode,
+        "mode":              inv_modes.get(dev.operational_mode, str(dev.operational_mode)),
         "target_c":          target_c,
         "target_f":          round(target_c * 9 / 5 + 32, 1) if target_c is not None else None,
         "fan_speed":         inv_fans.get(dev.fan_speed, str(dev.fan_speed)),
         "indoor_c":          indoor_c,
         "indoor_f":          round(indoor_c * 9 / 5 + 32, 1) if indoor_c is not None else None,
-        "freeze_protection": freeze_on,
+        "freeze_protection": bool(getattr(dev, "freeze_protection", False)),
     }
 
 
@@ -258,10 +261,15 @@ def set_state(power=None, mode=None, target_f=None, fan_speed=None):
     """
     Apply a partial state change. Any None argument keeps the dongle's current value.
 
-    mode='freeze' enables Midea's real Freeze Protection flag — the unit's display
-    shows "FP" and the firmware holds a minimum heat output (~8°C/46°F). When freeze
-    mode is set, target/fan/operational_mode are ignored: the unit drives them
-    internally. Setting any non-freeze mode automatically clears the freeze flag.
+    Does NOT control Freeze Prevention. The msmart `freeze_protection` flag is
+    purely cosmetic on this Durastar — the real ~46°F regulator is engaged only
+    by the IR remote (down-twice from 60°F), and any LAN apply() risks disturbing
+    the hidden regulator state. So during winter, while the unit is in IR-FP,
+    avoid calling this function — it will likely cancel the FP regulator.
+
+    Unrecognized `mode` values (including the legacy 'freeze' token from old
+    schedules) are ignored — they fall through the `mode in msmart_modes` filter
+    and don't change the unit's operational_mode.
 
     Returns True on success, False on error. On success, both reported and
     commanded views are persisted so the UI can show drift.
@@ -277,27 +285,11 @@ def set_state(power=None, mode=None, target_f=None, fan_speed=None):
     except Exception:
         return False
 
-    # Normalise inputs. MODE_FREEZE is special — it maps to the real freeze_protection
-    # flag, not to operational_mode. Any other explicit mode set forces freeze off.
-    set_freeze = None  # tri-state: True (turn on), False (turn off), None (don't touch)
-    if mode == MODE_FREEZE:
-        set_freeze = True
-        # The unit handles target/fan/mode internally while in FP. Force power on,
-        # clear the rest so we don't fight the firmware.
-        power = True
-        mode = None
-        target_f = None
-        fan_speed = None
-    elif mode is not None:
-        # User explicitly chose a non-freeze mode → exit FP if it was active.
-        set_freeze = False
-
     requested = {
         "power":     bool(power) if power is not None else None,
         "mode":      mode if (mode is not None and mode in msmart_modes) else None,
         "target_f":  float(target_f) if target_f is not None else None,
         "fan_speed": fan_speed if (fan_speed is not None and fan_speed in msmart_fans) else None,
-        "freeze":    set_freeze,
     }
 
     try:
@@ -313,10 +305,6 @@ def set_state(power=None, mode=None, target_f=None, fan_speed=None):
                 dev.target_temperature = _f_to_c(requested["target_f"])
             if requested["fan_speed"] is not None:
                 dev.fan_speed = msmart_fans[requested["fan_speed"]]
-            if requested["freeze"] is not None:
-                # NB: ignore dev.supports_freeze_protection — capability flags lie on
-                # some units (msmart-ng issue #76); the SetState bit is what counts.
-                dev.freeze_protection = requested["freeze"]
 
             await dev.apply()
             return _device_to_dict(dev)
@@ -324,18 +312,9 @@ def set_state(power=None, mode=None, target_f=None, fan_speed=None):
         post = _run_async(_apply())
         _save_reported(post)
 
-        # Build commanded view by overlaying requested fields on reported result.
-        # When we requested freeze=True, force commanded mode = MODE_FREEZE so the
-        # divergence detector compares apples to apples on the next refresh.
-        commanded_mode = post["mode"]
-        if requested["freeze"] is True:
-            commanded_mode = MODE_FREEZE
-        elif requested["mode"] is not None:
-            commanded_mode = requested["mode"]
-
         commanded = {
             "power":     post["power"]     if requested["power"]     is None else requested["power"],
-            "mode":      commanded_mode,
+            "mode":      post["mode"]      if requested["mode"]      is None else requested["mode"],
             "target_c":  post["target_c"]  if requested["target_f"]  is None else _f_to_c(requested["target_f"]),
             "target_f":  post["target_f"]  if requested["target_f"]  is None else round(requested["target_f"], 1),
             "fan_speed": post["fan_speed"] if requested["fan_speed"] is None else requested["fan_speed"],
@@ -351,8 +330,6 @@ def state_for_log():
     Return integer for readings.ac_state, suitable for log_temp.py to write
     into the per-minute row. Returns None if HVAC not configured or unreachable
     (so the column stays NULL rather than mis-recorded as 0/off).
-
-    Freeze Prevention is heat work; logged as AC_STATE_HEAT.
     """
     if not is_configured():
         return None
@@ -364,7 +341,6 @@ def state_for_log():
         return AC_STATE_OFF
     return {
         MODE_HEAT:   AC_STATE_HEAT,
-        MODE_FREEZE: AC_STATE_HEAT,
         MODE_COOL:   AC_STATE_COOL,
         MODE_FAN:    AC_STATE_FAN,
         MODE_DRY:    AC_STATE_DRY,

--- a/switch.py
+++ b/switch.py
@@ -287,19 +287,16 @@ def _handle(environ):
     # --- HVAC apply (immediate state change for Hangar HVAC) ---
     if qs.get("hvac_apply") == "1" and hvac.is_configured():
         hvac_mode = qs.get("hvac_mode", "")
-        if hvac_mode == hvac.MODE_FREEZE:
-            hvac.set_state(mode=hvac.MODE_FREEZE)
-        else:
-            try:
-                target_f = float(qs.get("hvac_target_f", "")) if qs.get("hvac_target_f") else None
-            except ValueError:
-                target_f = None
-            hvac.set_state(
-                power=(qs.get("hvac_power") == "1") if qs.get("hvac_power") in ("0", "1") else None,
-                mode=hvac_mode if hvac_mode in hvac.ALL_MODES else None,
-                target_f=target_f,
-                fan_speed=qs.get("hvac_fan_speed") if qs.get("hvac_fan_speed") in hvac.ALL_FANS else None,
-            )
+        try:
+            target_f = float(qs.get("hvac_target_f", "")) if qs.get("hvac_target_f") else None
+        except ValueError:
+            target_f = None
+        hvac.set_state(
+            power=(qs.get("hvac_power") == "1") if qs.get("hvac_power") in ("0", "1") else None,
+            mode=hvac_mode if hvac_mode in hvac.ALL_MODES else None,
+            target_f=target_f,
+            fan_speed=qs.get("hvac_fan_speed") if qs.get("hvac_fan_speed") in hvac.ALL_FANS else None,
+        )
         _redirect("switch.py")
 
     # --- Schedule add ---
@@ -337,16 +334,13 @@ def _handle(environ):
                     if sched_fan not in hvac.ALL_FANS:
                         sched_fan = "auto"
                     sched_power = qs.get("sched_hvac_power") == "1"
-                    if hvac_mode == hvac.MODE_FREEZE:
-                        params = {"mode": hvac.MODE_FREEZE}
-                    else:
-                        params = {
-                            "power": sched_power,
-                            "mode": hvac_mode,
-                            "fan_speed": sched_fan,
-                        }
-                        if sched_target_f is not None:
-                            params["target_f"] = sched_target_f
+                    params = {
+                        "power": sched_power,
+                        "mode": hvac_mode,
+                        "fan_speed": sched_fan,
+                    }
+                    if sched_target_f is not None:
+                        params["target_f"] = sched_target_f
                     conn = config.get_db()
                     conn.execute(
                         "INSERT OR REPLACE INTO schedules "
@@ -618,7 +612,6 @@ def _handle(environ):
         hvac_fans=[(f, hvac.FAN_LABELS[f]) for f in hvac.ALL_FANS],
         hvac_temp_min_f=hvac.TEMP_MIN_F,
         hvac_temp_max_f=hvac.TEMP_MAX_F,
-        hvac_mode_freeze=hvac.MODE_FREEZE,
     )
 
     return (
@@ -691,8 +684,10 @@ def _hvac_sched_label(params_json):
         p = json.loads(params_json)
     except (ValueError, TypeError):
         return "Set"
-    if p.get("mode") == hvac.MODE_FREEZE:
-        return hvac.MODE_LABELS[hvac.MODE_FREEZE]
+    if p.get("mode") == "freeze":
+        # Legacy schedule from before MODE_FREEZE was removed. The set_state
+        # call will silently no-op on this mode token, so flag it visibly here.
+        return "Freeze (legacy — won't run)"
     parts = []
     if p.get("power") is False:
         parts.append("Off")

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,6 +67,12 @@
   {% if hvac_state.stale %}
   <p class="mb-1 small text-warning">Stale: dongle last reachable {{ hvac_state.age_secs }}s ago.</p>
   {% endif %}
+  {% if r.freeze_protection %}
+  <div class="alert alert-warning py-2 mb-2 small">
+    Unit shows <b>FP</b> (Freeze Prevention, ~46&deg;F floor) &mdash; set via the IR remote.
+    Avoid using this card while FP is active; LAN commands will likely cancel the regulator.
+  </div>
+  {% endif %}
 
   <form action="switch.py" method="GET" class="row g-2 align-items-end mt-2">
     <input type="hidden" name="hvac_apply" value="1">
@@ -80,9 +86,9 @@
     <div class="col-auto">
       <label class="form-label mb-0 small">Mode</label>
       <select name="hvac_mode" class="form-select form-select-sm">
-        {% for val, label in hvac_modes %}{% if val != hvac_mode_freeze %}
+        {% for val, label in hvac_modes %}
         <option value="{{ val }}"{% if r.mode == val %} selected{% endif %}>{{ label }}</option>
-        {% endif %}{% endfor %}
+        {% endfor %}
       </select>
     </div>
     <div class="col-auto">
@@ -104,11 +110,6 @@
     </div>
   </form>
 
-  <form action="switch.py" method="GET" class="d-inline">
-    <input type="hidden" name="hvac_apply" value="1">
-    <input type="hidden" name="hvac_mode" value="{{ hvac_mode_freeze }}">
-    <button type="submit" class="btn btn-outline-info btn-sm mt-2">Freeze Prevention preset</button>
-  </form>
 {% endif %}
 </div>
 </div>
@@ -356,16 +357,8 @@ function schedToggle() {
   if (device === 'hvac') schedHvacModeToggle();
 }
 function schedHvacModeToggle() {
-  var modeSel = document.getElementById('sched_hvac_mode');
-  if (!modeSel) return;
-  var mode = modeSel.value;
-  // Freeze Prevention preset = no extra fields
-  var isFreeze = mode === 'freeze';
-  ['sched-hvac-temp', 'sched-hvac-fan', 'sched-hvac-power'].forEach(function(cls) {
-    document.querySelectorAll('.' + cls).forEach(function(el) {
-      el.style.display = isFreeze ? 'none' : '';
-    });
-  });
+  // Reserved for future per-mode field toggling; currently every HVAC mode
+  // uses the same set of fields (temp, fan, power) so there's nothing to do.
 }
 </script>
 {% if pending_sched_rows %}


### PR DESCRIPTION
## Summary
- PR #5 added a Freeze Prevention preset on the assumption that msmart-ng's LAN `freeze_protection` flag engaged the unit's real ~46°F regulator. Field testing on 2026-05-05 disproved that — the LAN flag is purely cosmetic on this Durastar DRAW33F2A.
- Real FP is engaged only by the IR remote (down-twice from 60°F) via a hidden register the LAN protocol can't read or write. Months of probe data confirm IR-FP holds a 46°F floor; today's wire-byte diff confirms LAN-FP is identical bytes but doesn't engage the regulator.
- Remove `MODE_FREEZE` from the UI, schedule path, dropdown, and preset button. `set_state` no longer touches `dev.freeze_protection`. The HVAC card shows a warning banner when `freeze_protection: True` is reported, telling the user not to send LAN commands while IR-FP is active.

## Diagnostic evidence
- **Wire bytes** (IR-FP vs msmart 2-apply FP): byte-for-byte identical except the indoor/outdoor 0.1°C fraction byte and the sequence counter. No FP-relevant byte differs.
- **`min_target_temperature: 16`** — the dongle clamps any LAN target below 60.8°F. The IR remote bypasses this clamp via the FP sequence.
- **`PropertyId 0x0213` (PRESET_FREEZE_PROTECTION)** — querying via 0xB1 returns size=0 with the error bit set, so the regulator setpoint isn't exposed via the property mechanism either.
- **Probe history** — May 1: hangar floor 45.7°F against 32°F ambient under IR-FP; today: with `freeze_protection: True` set via msmart, the unit heated to 60°F (the `target_temperature`).

## What still works
- Heat / Cool / Auto / Dry / Fan modes via the web UI and scheduler — unchanged.
- Schedules with `mode in {auto, cool, dry, heat, fan}` — unchanged.
- Legacy schedules with `mode: "freeze"` — silently no-op (row still deleted on fire); rendered as "Freeze (legacy — won't run)" in the pending list.
- Freeze prevention on the unit — engage via IR remote (down-twice from 60°F) as before. Don't touch the web UI's HVAC card while it's active or the LAN apply() will likely cancel the regulator.

## Test plan
- [ ] Pull on the Pi, confirm mod_wsgi auto-reloads (`switch.py` mtime change should be enough).
- [ ] Open the web UI, confirm the HVAC card mode dropdown no longer includes "Freeze Prevention" and the standalone preset button is gone.
- [ ] With the unit in IR-FP, refresh the page and confirm the warning banner appears.
- [ ] Confirm Heat / Cool / Fan / Auto / Dry still apply correctly via the form.
- [ ] (Skip — IR-FP regulator is the user's problem to re-engage at the hangar after my testing today disturbed it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)