### PR TITLE
Fix broken chart on main — revert dayjs adapter swap

### DIFF
--- a/scripts/check-cdn-versions.sh
+++ b/scripts/check-cdn-versions.sh
@@ -10,8 +10,7 @@ cd "$(dirname "$0")/.."
 pkgs=(
   bootstrap
   chart.js
-  dayjs
-  chartjs-adapter-dayjs-4
+  chartjs-adapter-date-fns
   chartjs-plugin-zoom
 )
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,8 +12,7 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
 {% if enable_temp %}
 <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/dayjs@1.11.20/dayjs.min.js" integrity="sha384-DpVxUeeBWjUvUV1czyIHJAjh+jYUZFu2lLakbdua5vbwOrBGi1UgaKCHjTC+x3Ky" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-dayjs-4@1.0.4" integrity="sha384-K2yT+FlpUIfAz5yqqqF6btJ+wPytE+Dhq+hENAQ0pPXhmelRLrf5nK5XHpQdYD+V" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0" integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.2.0" integrity="sha384-dwwI6ICEN/0ZQlS5owhUa/6ZzvwUPmjH45bFVCAcjgjTulbHJvlE+TGU3g1k0N3R" crossorigin="anonymous"></script>
 {% endif %}
 </head>


### PR DESCRIPTION
## Summary

PR #15 merged with a broken chart (the dayjs adapter swap). This PR reverts just that one change.

**Symptom on main:** chart canvas blank — only legend chips and range buttons render.

**Root cause:** \`chartjs-adapter-dayjs-4@1.0.4\` only ships CJS and ESM builds, no UMD/IIFE. The bare jsdelivr URL resolved to the CJS bundle, which references \`process.env\` and throws in the browser:

\`\`\`
Uncaught ReferenceError: process is not defined
    at chartjs-adapter-dayjs-4@1.0.4:7:29
\`\`\`

Chart.js then fails its scale init: \`This method is not implemented: Check that a complete date adapter is provided.\`

**Fix:** restore \`chartjs-adapter-date-fns@3.0.0\` (proper UMD bundle). All other tier-1 wins from PR #15 stay in place — defer + DOMContentLoaded, the preconnect hint, and the inline \`coldBandPlugin\` replacing chartjs-plugin-annotation.

Net wire saving for the perf work drops from ~24 KB → ~13 KB, but the chart actually renders.

## Test plan
- [x] Diagnosed via Chrome DevTools console on \`10.8.0.17/cgi-bin/remote-switch/switch.py?range=1d\` after the broken deploy.
- [x] \`./scripts/check-cdn-versions.sh\` exits 0 on this branch.
- [ ] After merge + Pi \`git pull\`, reload the heater UI: chart canvas renders, time-axis labels show (\`HH:mm\`/\`MMM d\`/\`MMM yyyy\`), wheel/pinch zoom works, **Reset zoom** button toggles, **cold-band orange overlays** draw at <=48°F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)