### PR TITLE
Chart: index-mode tooltip showing every series at the cursor's x

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -495,8 +495,50 @@ if (data.length > 0) {
     },
     options: {
       responsive: true,
+      // Tooltip triggers anywhere along the x-axis and shows every dataset
+      // that has a value at that time. Datasets with null y at this x are
+      // hidden by `tooltip.filter`, which collapses the heater/fan/HVAC-W
+      // bands into "Heater on" / "Fan on" / "HVAC: NW" presence labels and
+      // skips them when off. The cold band is a custom plugin, not a
+      // dataset, so its label is appended via tooltip.callbacks.afterBody.
+      interaction: {
+        mode: 'index',
+        intersect: false
+      },
       plugins: {
         legend: { display: false },
+        tooltip: {
+          filter: function(item) {
+            return item.parsed.y !== null && item.parsed.y !== undefined;
+          },
+          callbacks: {
+            label: function(item) {
+              var idx = item.datasetIndex;
+              if (idx === 0) return 'Hangar: ' + item.parsed.y.toFixed(1) + '°F';
+              if (idx === 1) return 'Heater on';
+              if (idx === 2) return 'Fan on';
+              if (idx === 3) return 'Ambient: ' + item.parsed.y.toFixed(1) + '°F';
+              if (idx === 4) return 'HVAC: ' + item.parsed.y.toFixed(0) + ' W';
+              return '';
+            },
+            labelColor: function(item) {
+              if (item.datasetIndex === 1) return { borderColor: 'rgba(220, 53, 69, 0.5)', backgroundColor: 'rgba(220, 53, 69, 0.5)' };
+              if (item.datasetIndex === 2) return { borderColor: 'rgba(13, 110, 253, 0.5)', backgroundColor: 'rgba(13, 110, 253, 0.5)' };
+              var c = item.dataset.borderColor;
+              return { borderColor: c, backgroundColor: c };
+            },
+            afterBody: function(items) {
+              if (!items.length || !coldRanges.length) return [];
+              var x = items[0].parsed.x;
+              for (var i = 0; i < coldRanges.length; i++) {
+                if (x >= coldRanges[i].xMin && x <= coldRanges[i].xMax) {
+                  return ['≤ 48°F'];
+                }
+              }
+              return [];
+            }
+          }
+        },
         zoom: {
           zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' },
           pan: { enabled: true, mode: 'x' }


### PR DESCRIPTION
## Summary

Vertical hover anywhere in the chart area now shows everything that applies at that time, not just the single line being hovered.

**Per-series rendering:**
- **Hangar / Ambient** — \`Hangar: 54.1°F\` / \`Ambient: 32.0°F\`
- **HVAC W** — \`HVAC: 320 W\` (already only present in buckets above the standby threshold; absent rows naturally drop out)
- **Heater on** / **Fan on** — presence labels only, hidden when off (the underlying range datasets are y=null when off, so the generic null-y filter handles this without per-dataset logic)
- **≤ 48°F** — appended via \`tooltip.callbacks.afterBody\` when the hovered x falls inside any \`coldRange\`. The cold band is the inline \`coldBandPlugin\` from PR #15, not a dataset, so it can't go through the normal tooltip path.

**Implementation notes:**
- \`interaction: { mode: 'index', intersect: false }\` — triggers anywhere along the x-axis, not only when hovering a data point.
- \`tooltip.filter\` returns \`false\` for any item whose \`parsed.y\` is null/undefined. This is what makes Heater/Fan/HVAC-W presence-based.
- \`tooltip.callbacks.labelColor\` overrides the swatch for Heater/Fan (whose dataset \`borderColor\` is \`transparent\`) so the tooltip swatch reads as red/blue.
- \`afterBody\` returns \`['≤ 48°F']\` or \`[]\` based on cold-range membership. No swatch — it's a synthetic line.

## Test plan
- [x] \`./scripts/check-cdn-versions.sh\` exits 0.
- [x] \`node --check\` parses the inline JS cleanly.
- [ ] After merge + Pi \`git pull\`, hover the chart at the same time as the screenshot in the request:
  - In the orange (≤48°F) section: should show \`Hangar\`, \`Ambient\`, \`≤ 48°F\` (no Heater/Fan/HVAC unless they were also on at that minute)
  - Outside the orange section: same minus the \`≤ 48°F\` line
  - In a heater-on / fan-on stretch: \`Heater on\` / \`Fan on\` lines appear with the right swatch color
  - HVAC W only appears in buckets where the unit was actually drawing >100W

🤖 Generated with [Claude Code](https://claude.com/claude-code)