### PR TITLE
fix(chart): distinct fuchsia for door marker + add legend entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ The wrappers were verified against msmart-ng 2025.12.0. If you upgrade, watch th
 - Heater band (engine-block) — `rgba(220, 53, 69, 0.25)` red
 - Fan band — `rgba(13, 110, 253, 0.20)` blue
 - Cold annotation (≤48°F) — `rgba(255, 152, 0, 0.15)` orange box
-- Door-open marker — `rgba(245, 158, 11, 0.45)` amber bar; computed by `aggregate.detect_door_events()` from raw per-minute rows (1d/7d only — 30d/monthly skipped because events would render as overlapping pixels). Tooltip shows `Door event (cold air in / warm air in, N°F peak)`.
+- Door-open marker — `rgba(219, 39, 119, 0.55)` fuchsia bar (distinct from the orange cold annotation); computed by `aggregate.detect_door_events()` from raw per-minute rows (1d/7d only — 30d/monthly skipped because events would render as overlapping pixels). Tooltip shows `Door event (cold air in / warm air in, N°F peak)`.
 - Hangar temp line — `rgb(75, 192, 192)` teal (left y-axis, °F)
 - Ambient line — `rgb(34, 197, 94)` green (left y-axis, °F)
 - HVAC power line — `rgb(168, 85, 247)` purple (**right y-axis, Watts**)

--- a/templates/index.html
+++ b/templates/index.html
@@ -146,6 +146,7 @@
     <span class="ms-3 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(220,53,69,0.3);vertical-align:middle"></span> Heater on</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(13,110,253,0.3);vertical-align:middle"></span> Fan on</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:12px;height:12px;background:rgba(255,152,0,0.3);vertical-align:middle"></span> &le; 48&deg;F</span>
+    <span class="ms-2 small text-muted"><span style="display:inline-block;width:6px;height:12px;background:rgba(219,39,119,0.6);vertical-align:middle"></span> Door open</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:20px;border-top:2px solid rgb(75,192,192);vertical-align:middle"></span> Hangar</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:20px;border-top:2px solid rgb(34,197,94);vertical-align:middle"></span> Ambient</span>
     <span class="ms-2 small text-muted"><span style="display:inline-block;width:20px;border-top:2px solid rgb(168,85,247);vertical-align:middle"></span> HVAC W</span>
@@ -446,7 +447,7 @@ var doorBandPlugin = {
     var area = chart.chartArea;
     var xScale = chart.scales.x;
     ctx.save();
-    ctx.fillStyle = 'rgba(245, 158, 11, 0.45)';
+    ctx.fillStyle = 'rgba(219, 39, 119, 0.55)';  // fuchsia — distinct from orange cold band
     doorRanges.forEach(function(r) {
       var x0 = Math.max(area.left, xScale.getPixelForValue(r.xMin));
       var x1 = Math.min(area.right, xScale.getPixelForValue(r.xMax));


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #22. The amber `rgba(245,158,11,0.45)` door bar was visually indistinguishable from the orange `rgba(255,152,0,0.3)` ≤48°F cold annotation, and there was no legend entry to disambiguate.
- Switches the door bar to fuchsia `rgba(219,39,119,0.55)` — distinct from every other band in the palette (red heater / blue fan / orange cold / teal hangar / green ambient / purple HVAC line).
- Adds a "Door open" entry to the hand-built legend strip in `templates/index.html` between the cold annotation and the Hangar line. Uses a narrower 6px-wide swatch to visually communicate "vertical bar" vs the 12px square swatches used for full-area bands.

## Why this was needed
On a 1d chart the bar is only ~5-15 minutes wide; without a distinct color and a legend label, a glance at the chart can't tell a door event from the cold annotation. User flagged this immediately on first deploy.

## Test plan
- [ ] Reload the dashboard at `?range=1d` and confirm the bar at 2026-05-08 07:46-07:57 is now bright pink/fuchsia instead of amber-orange
- [ ] Confirm the new "Door open" entry shows in the legend strip below the range buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)