### PR TITLE
perf(ui): lazy-load monthly stats + HVAC card (TTFB ~10s -> ~1s)

### DIFF
--- a/switch.py
+++ b/switch.py
@@ -119,6 +119,64 @@ def _month_data(mk, label, ts, as_, rs, t_pct):
 # Old-cache row helpers (from migrate.py, pre-rendered HTML from .dat files)
 # ---------------------------------------------------------------------------
 
+def _compute_months_data(conn, now_epoch=None):
+    """Build the 13-month stats list. Slow on Pi Zero W (~6s SQL scan), so the
+    main page render skips this — clients fetch it via ?monthly_stats=1 after
+    page load. Reused from both the lazy endpoint and the full-page render."""
+    if now_epoch is None:
+        now_epoch = int(datetime.now().timestamp())
+    cur_month_date = date.today().replace(day=1)
+    months_data = []
+
+    month_meta = []
+    for i in range(13):
+        md = config.subtract_months(cur_month_date, i)
+        mk = md.strftime("%Y-%m")
+        lbl = _month_label(md)
+        m_start, m_end = _month_bounds(md)
+        is_current = md == cur_month_date
+        effective_end = min(m_end, now_epoch) if is_current else m_end
+        month_meta.append((mk, lbl, m_start, m_end, effective_end, is_current))
+
+    all_mks = [m[0] for m in month_meta]
+    placeholders = ",".join("?" * len(all_mks))
+    cache_map = {
+        row[0]: json.loads(row[1])
+        for row in conn.execute(
+            f"SELECT month, data FROM monthly_cache WHERE month IN ({placeholders})",
+            all_mks,
+        ).fetchall()
+    }
+
+    live_month_meta = [m for m in month_meta if m[5] or m[0] not in cache_map]
+    live_batch_stats = {}
+    if live_month_meta:
+        batch_start = min(m[2] for m in live_month_meta)
+        batch_end = max(m[4] for m in live_month_meta)
+        live_batch_stats = config.query_batch_stats(conn, batch_start, batch_end)
+
+    for mk, lbl, m_start, m_end, effective_end, is_current in month_meta:
+        cached = cache_map.get(mk) if not is_current else None
+        if cached:
+            if "_html_temp" in cached:
+                continue
+            ts = cached.get("temp_stats")
+            as_ = cached.get("ambient_stats")
+            rs = cached.get("runtime_stats")
+            if ts and rs:
+                t_pct = rs.get("temp_coverage_pct", 0)
+                months_data.append(_month_data(mk, lbl, ts, as_, rs, t_pct))
+        else:
+            sql_row = live_batch_stats.get(mk)
+            if not sql_row:
+                continue
+            ts, as_, rs = _build_stats(sql_row, m_start, effective_end)
+            if ts and rs:
+                t_pct = rs.get("temp_coverage_pct", 0)
+                months_data.append(_month_data(mk, lbl, ts, as_, rs, t_pct))
+    return months_data
+
+
 def _old_cache_temp_row(mk, html_row):
     """Add onclick to a pre-rendered HTML temp row from old .dat cache."""
     row = html_row.replace(
@@ -253,6 +311,40 @@ def _handle(environ):
         if not wx_id and not (wx_lat and wx_lon):
             result = ""
         _respond("text/plain", result)
+
+    # --- Lazy-loaded HVAC card body (~3.8s for dongle round-trip) ---
+    # The main page render skips hvac.get_state() and shows a spinner;
+    # client-side JS fetches this and swaps it into #hvac-card-body.
+    if qs.get("hvac_state") == "1":
+        hvac_configured = hvac.is_configured()
+        hvac_state = hvac.get_state() if hvac_configured else None
+        tmpl = _get_jinja_env().get_template("_hvac_card.html")
+        body_html = tmpl.render(
+            hvac_configured=hvac_configured,
+            hvac_state=hvac_state,
+            hvac_modes=[(m, hvac.MODE_LABELS[m]) for m in hvac.ALL_MODES],
+            hvac_fans=[(f, hvac.FAN_LABELS[f]) for f in hvac.ALL_FANS],
+            hvac_temp_min_f=hvac.TEMP_MIN_F,
+            hvac_temp_max_f=hvac.TEMP_MAX_F,
+            hvac_mode_freeze=hvac.MODE_FREEZE,
+        )
+        power_on = bool(
+            hvac_state and hvac_state.get("reported")
+            and hvac_state["reported"].get("power")
+        )
+        _respond("application/json", json.dumps({"power_on": power_on, "html": body_html}))
+
+    # --- Lazy-loaded monthly stats table (~6.7s SQL scan on Pi Zero W) ---
+    # Same pattern: main page skips it, client JS fetches and swaps into
+    # #monthly-stats-body. Drops main TTFB by ~6s.
+    if qs.get("monthly_stats") == "1":
+        conn = config.get_db()
+        try:
+            months_data = _compute_months_data(conn)
+        finally:
+            conn.close()
+        tmpl = _get_jinja_env().get_template("_monthly_stats.html")
+        _respond("text/html", tmpl.render(months_data=months_data))
 
     # --- GPIO check ---
     gpio_path = config._gpio_path()
@@ -429,9 +521,11 @@ def _handle(environ):
             amb_f = amb_c * 1.8 + 32
             ambient_display = f"{amb_c:.1f} \u00b0C | {amb_f:.1f} \u00b0F"
 
-    # --- HVAC state ---
+    # --- HVAC state — lazy-loaded by client JS via ?hvac_state=1 ---
+    # The dongle round-trip can take 3-4s on cache miss; deferring it drops
+    # main TTFB. is_configured() is a cheap .env check, kept here so the
+    # template can render the spinner skeleton (vs "Not configured" text).
     hvac_configured = hvac.is_configured()
-    hvac_state = hvac.get_state() if hvac_configured else None
 
     # --- Pending schedules ---
     conn = config.get_db()
@@ -546,58 +640,9 @@ def _handle(environ):
                 pairs = config.query_temp_pairs(conn, chart_cutoff, chart_end_epoch)
                 door_ranges = aggregate.detect_door_events(pairs)
 
-        # Build per-month stats (13 months) with batch queries
-        month_meta = []
-        for i in range(13):
-            md = config.subtract_months(cur_month_date, i)
-            mk = md.strftime("%Y-%m")
-            lbl = _month_label(md)
-            m_start, m_end = _month_bounds(md)
-            is_current = md == cur_month_date
-            effective_end = min(m_end, now_epoch) if is_current else m_end
-            month_meta.append((mk, lbl, m_start, m_end, effective_end, is_current))
-
-        # Fetch all cache rows in one query
-        all_mks = [m[0] for m in month_meta]
-        placeholders = ",".join("?" * len(all_mks))
-        cache_map = {
-            row[0]: json.loads(row[1])
-            for row in conn.execute(
-                f"SELECT month, data FROM monthly_cache WHERE month IN ({placeholders})",
-                all_mks,
-            ).fetchall()
-        }
-
-        # Single SQL query for all uncached months' stats (replaces N Python aggregate.compute calls)
-        live_month_meta = [
-            m for m in month_meta if m[5] or m[0] not in cache_map  # is_current or uncached
-        ]
-        live_batch_stats = {}
-        if live_month_meta:
-            batch_start = min(m[2] for m in live_month_meta)
-            batch_end = max(m[4] for m in live_month_meta)
-            live_batch_stats = config.query_batch_stats(conn, batch_start, batch_end)
-
-        for mk, lbl, m_start, m_end, effective_end, is_current in month_meta:
-            cached = cache_map.get(mk) if not is_current else None
-
-            if cached:
-                if "_html_temp" in cached:
-                    continue  # old pre-migration format — incompatible with merged table
-                ts = cached.get("temp_stats")
-                as_ = cached.get("ambient_stats")
-                rs = cached.get("runtime_stats")
-                if ts and rs:
-                    t_pct = rs.get("temp_coverage_pct", 0)
-                    months_data.append(_month_data(mk, lbl, ts, as_, rs, t_pct))
-            else:
-                sql_row = live_batch_stats.get(mk)
-                if not sql_row:
-                    continue
-                ts, as_, rs = _build_stats(sql_row, m_start, effective_end)
-                if ts and rs:
-                    t_pct = rs.get("temp_coverage_pct", 0)
-                    months_data.append(_month_data(mk, lbl, ts, as_, rs, t_pct))
+        # Monthly stats are lazy-loaded by client JS via ?monthly_stats=1.
+        # Computing them inline adds ~6.7s on a Pi Zero W (full SQL scan over
+        # current month's readings + cache lookups). Skipping here drops TTFB.
 
         conn.close()
 
@@ -629,14 +674,14 @@ def _handle(environ):
         door_ranges=door_ranges,
         ambient_data=ambient_data,
         power_data=power_data,
-        months_data=months_data,
         sched_msg=sched_msg,
         pending_sched_rows=pending_sched_rows,
         now_dt_min=now_dt_min,
         now_str=now_str,
-        # HVAC
+        # HVAC — the card body (with live state + apply form) is loaded via
+        # JS through ?hvac_state=1; only the static enums needed by the
+        # schedule form's dropdowns and the spinner header are passed here.
         hvac_configured=hvac_configured,
-        hvac_state=hvac_state,
         hvac_modes=[(m, hvac.MODE_LABELS[m]) for m in hvac.ALL_MODES],
         hvac_fans=[(f, hvac.FAN_LABELS[f]) for f in hvac.ALL_FANS],
         hvac_temp_min_f=hvac.TEMP_MIN_F,

--- a/templates/_hvac_card.html
+++ b/templates/_hvac_card.html
@@ -1,0 +1,70 @@
+{% if not hvac_configured %}
+  <p class="mb-1">Not configured.</p>
+  <p class="small text-muted mb-0">Pair the Midea WiFi dongle via NetHome Plus on your phone, then run <code>python3 setup_hvac.py</code> on the Pi.</p>
+{% elif not hvac_state or not hvac_state.reported %}
+  <p class="text-danger mb-0">HVAC dongle unreachable. Check power and network.</p>
+{% else %}
+  {% set r = hvac_state.reported %}
+  <h5 class="card-title">
+    Status: <b>{{ "ON" if r.power else "OFF" }}</b>
+    {% if r.power %} &middot; Mode: <b>{{ r.mode|capitalize }}</b>
+    {% if r.target_f is not none %} &middot; Target: <b>{{ "%.0f"|format(r.target_f) }}&deg;F / {{ "%.1f"|format(r.target_c) }}&deg;C</b>{% endif %}
+    {% endif %}
+  </h5>
+  {% if r.indoor_f is not none %}
+  <p class="mb-1 small">Indoor unit thermistor: <b>{{ "%.1f"|format(r.indoor_f) }}&deg;F / {{ "%.1f"|format(r.indoor_c) }}&deg;C</b></p>
+  {% endif %}
+  {% if hvac_state.diverged and hvac_state.commanded %}
+  {% set c = hvac_state.commanded %}
+  <p class="mb-1 small text-warning">
+    <strong>Last commanded:</strong>
+    {% if c.power %}{{ c.mode|capitalize }}{% if c.target_f is not none %} {{ "%.0f"|format(c.target_f) }}&deg;F{% endif %}, fan {{ c.fan_speed }}{% else %}OFF{% endif %}
+    &mdash; physical remote may have been used.
+  </p>
+  {% endif %}
+  {% if hvac_state.stale %}
+  <p class="mb-1 small text-warning">Stale: dongle last reachable {{ hvac_state.age_secs }}s ago.</p>
+  {% endif %}
+
+  <form action="switch.py" method="GET" class="row g-2 align-items-end mt-2">
+    <input type="hidden" name="hvac_apply" value="1">
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Power</label>
+      <select name="hvac_power" class="form-select form-select-sm">
+        <option value="1"{% if r.power %} selected{% endif %}>On</option>
+        <option value="0"{% if not r.power %} selected{% endif %}>Off</option>
+      </select>
+    </div>
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Mode</label>
+      <select name="hvac_mode" class="form-select form-select-sm">
+        {% for val, label in hvac_modes %}{% if val != hvac_mode_freeze %}
+        <option value="{{ val }}"{% if r.mode == val %} selected{% endif %}>{{ label }}</option>
+        {% endif %}{% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Target &deg;F</label>
+      <input type="number" name="hvac_target_f" class="form-control form-control-sm"
+             min="{{ hvac_temp_min_f }}" max="{{ hvac_temp_max_f }}" step="1"
+             value="{{ "%.0f"|format(r.target_f) if r.target_f is not none else 70 }}" style="width:5em">
+    </div>
+    <div class="col-auto">
+      <label class="form-label mb-0 small">Fan</label>
+      <select name="hvac_fan_speed" class="form-select form-select-sm">
+        {% for val, label in hvac_fans %}
+        <option value="{{ val }}"{% if r.fan_speed == val %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary btn-sm">Apply</button>
+    </div>
+  </form>
+
+  <form action="switch.py" method="GET" class="d-inline">
+    <input type="hidden" name="hvac_apply" value="1">
+    <input type="hidden" name="hvac_mode" value="{{ hvac_mode_freeze }}">
+    <button type="submit" class="btn btn-outline-info btn-sm mt-2">Freeze Prevention preset</button>
+  </form>
+{% endif %}

--- a/templates/_monthly_stats.html
+++ b/templates/_monthly_stats.html
@@ -1,0 +1,87 @@
+{% if months_data %}
+<div class="stats-wrap" id="statsWrap">
+<div class="table-responsive">
+<table class="table table-sm table-striped table-hover mb-0 stats-table">
+<thead>
+<tr>
+  <th class="stats-metric-col">Metric</th>
+  {% for m in months_data %}
+  <th class="text-end stats-month-col" onclick="location='switch.py?range={{ m.mk }}'" style="cursor:pointer">
+    {{ m.label }}{% if m.coverage_pct < 100 %}<br><span class="small text-muted fw-normal">{{ "%.1f"|format(m.coverage_pct) }}%</span>{% endif %}
+  </th>
+  {% endfor %}
+</tr>
+</thead>
+<tbody>
+<tr class="stats-group"><td colspan="{{ months_data|length + 1 }}" class="fw-semibold small text-uppercase text-muted">Hangar</td></tr>
+<tr>
+  <td class="stats-metric-col ps-3">Avg</td>
+  {% for m in months_data %}
+  <td class="text-end"><span class="unit-f">{{ "%.1f"|format(m.hangar.avg_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.hangar.avg_c) }}&deg;C</span></td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3">Min</td>
+  {% for m in months_data %}
+  <td class="text-end"><span class="unit-f">{{ "%.1f"|format(m.hangar.min_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.hangar.min_c) }}&deg;C</span></td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3">Max</td>
+  {% for m in months_data %}
+  <td class="text-end"><span class="unit-f">{{ "%.1f"|format(m.hangar.max_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.hangar.max_c) }}&deg;C</span></td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3"><span class="unit-f">Hrs &le; 48&deg;F</span><span class="unit-c">Hrs &le; 8.9&deg;C</span></td>
+  {% for m in months_data %}
+  <td class="text-end">{{ "%.1f"|format(m.hangar.cold_hrs) }}</td>
+  {% endfor %}
+</tr>
+{% if months_data|selectattr('outdoor')|list %}
+<tr class="stats-group"><td colspan="{{ months_data|length + 1 }}" class="fw-semibold small text-uppercase text-muted">Outdoor</td></tr>
+<tr>
+  <td class="stats-metric-col ps-3">Avg</td>
+  {% for m in months_data %}
+  <td class="text-end">{% if m.outdoor %}<span class="unit-f">{{ "%.1f"|format(m.outdoor.avg_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.outdoor.avg_c) }}&deg;C</span>{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3">Min</td>
+  {% for m in months_data %}
+  <td class="text-end">{% if m.outdoor %}<span class="unit-f">{{ "%.1f"|format(m.outdoor.min_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.outdoor.min_c) }}&deg;C</span>{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3">Max</td>
+  {% for m in months_data %}
+  <td class="text-end">{% if m.outdoor %}<span class="unit-f">{{ "%.1f"|format(m.outdoor.max_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.outdoor.max_c) }}&deg;C</span>{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3"><span class="unit-f">Hrs &le; 48&deg;F</span><span class="unit-c">Hrs &le; 8.9&deg;C</span></td>
+  {% for m in months_data %}
+  <td class="text-end">{% if m.outdoor %}{{ "%.1f"|format(m.outdoor.cold_hrs) }}{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
+  {% endfor %}
+</tr>
+{% endif %}
+<tr class="stats-group"><td colspan="{{ months_data|length + 1 }}" class="fw-semibold small text-uppercase text-muted">Runtime</td></tr>
+<tr>
+  <td class="stats-metric-col ps-3">Heater</td>
+  {% for m in months_data %}
+  <td class="text-end">{{ m.heater_str if m.heater_str else '—' }}</td>
+  {% endfor %}
+</tr>
+<tr>
+  <td class="stats-metric-col ps-3">Fan</td>
+  {% for m in months_data %}
+  <td class="text-end">{{ m.fan_str if m.fan_str else '—' }}</td>
+  {% endfor %}
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+{% else %}
+<p class="text-muted m-3 mb-0">No monthly data yet.</p>
+{% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,81 +34,17 @@
 </div>
 </div>
 
-<div class="card mb-3">
-<div class="card-header {% if hvac_state and hvac_state.reported and hvac_state.reported.power %}text-bg-info{% else %}text-bg-secondary{% endif %}">
+<div class="card mb-3" id="hvac-card">
+<div class="card-header text-bg-secondary" id="hvac-card-header">
   <h4>Hangar HVAC</h4>
 </div>
-<div class="card-body">
-{% if not hvac_configured %}
-  <p class="mb-1">Not configured.</p>
-  <p class="small text-muted mb-0">Pair the Midea WiFi dongle via NetHome Plus on your phone, then run <code>python3 setup_hvac.py</code> on the Pi.</p>
-{% elif not hvac_state or not hvac_state.reported %}
-  <p class="text-danger mb-0">HVAC dongle unreachable. Check power and network.</p>
-{% else %}
-  {% set r = hvac_state.reported %}
-  <h5 class="card-title">
-    Status: <b>{{ "ON" if r.power else "OFF" }}</b>
-    {% if r.power %} &middot; Mode: <b>{{ r.mode|capitalize }}</b>
-    {% if r.target_f is not none %} &middot; Target: <b>{{ "%.0f"|format(r.target_f) }}&deg;F / {{ "%.1f"|format(r.target_c) }}&deg;C</b>{% endif %}
-    {% endif %}
-  </h5>
-  {% if r.indoor_f is not none %}
-  <p class="mb-1 small">Indoor unit thermistor: <b>{{ "%.1f"|format(r.indoor_f) }}&deg;F / {{ "%.1f"|format(r.indoor_c) }}&deg;C</b></p>
-  {% endif %}
-  {% if hvac_state.diverged and hvac_state.commanded %}
-  {% set c = hvac_state.commanded %}
-  <p class="mb-1 small text-warning">
-    <strong>Last commanded:</strong>
-    {% if c.power %}{{ c.mode|capitalize }}{% if c.target_f is not none %} {{ "%.0f"|format(c.target_f) }}&deg;F{% endif %}, fan {{ c.fan_speed }}{% else %}OFF{% endif %}
-    &mdash; physical remote may have been used.
-  </p>
-  {% endif %}
-  {% if hvac_state.stale %}
-  <p class="mb-1 small text-warning">Stale: dongle last reachable {{ hvac_state.age_secs }}s ago.</p>
-  {% endif %}
-
-  <form action="switch.py" method="GET" class="row g-2 align-items-end mt-2">
-    <input type="hidden" name="hvac_apply" value="1">
-    <div class="col-auto">
-      <label class="form-label mb-0 small">Power</label>
-      <select name="hvac_power" class="form-select form-select-sm">
-        <option value="1"{% if r.power %} selected{% endif %}>On</option>
-        <option value="0"{% if not r.power %} selected{% endif %}>Off</option>
-      </select>
+<div class="card-body" id="hvac-card-body">
+  <div class="d-flex justify-content-center align-items-center py-3">
+    <div class="spinner-border spinner-border-sm text-secondary me-2" role="status">
+      <span class="visually-hidden">Loading...</span>
     </div>
-    <div class="col-auto">
-      <label class="form-label mb-0 small">Mode</label>
-      <select name="hvac_mode" class="form-select form-select-sm">
-        {% for val, label in hvac_modes %}{% if val != hvac_mode_freeze %}
-        <option value="{{ val }}"{% if r.mode == val %} selected{% endif %}>{{ label }}</option>
-        {% endif %}{% endfor %}
-      </select>
-    </div>
-    <div class="col-auto">
-      <label class="form-label mb-0 small">Target &deg;F</label>
-      <input type="number" name="hvac_target_f" class="form-control form-control-sm"
-             min="{{ hvac_temp_min_f }}" max="{{ hvac_temp_max_f }}" step="1"
-             value="{{ "%.0f"|format(r.target_f) if r.target_f is not none else 70 }}" style="width:5em">
-    </div>
-    <div class="col-auto">
-      <label class="form-label mb-0 small">Fan</label>
-      <select name="hvac_fan_speed" class="form-select form-select-sm">
-        {% for val, label in hvac_fans %}
-        <option value="{{ val }}"{% if r.fan_speed == val %} selected{% endif %}>{{ label }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="col-auto">
-      <button type="submit" class="btn btn-primary btn-sm">Apply</button>
-    </div>
-  </form>
-
-  <form action="switch.py" method="GET" class="d-inline">
-    <input type="hidden" name="hvac_apply" value="1">
-    <input type="hidden" name="hvac_mode" value="{{ hvac_mode_freeze }}">
-    <button type="submit" class="btn btn-outline-info btn-sm mt-2">Freeze Prevention preset</button>
-  </form>
-{% endif %}
+    <span class="text-muted small">Reading dongle&hellip;</span>
+  </div>
 </div>
 </div>
 
@@ -177,94 +113,13 @@
     <label class="btn btn-outline-secondary" for="statsUnitC">&deg;C</label>
   </div>
 </div>
-<div class="card-body p-0">
-{% if months_data %}
-<div class="stats-wrap" id="statsWrap">
-<div class="table-responsive">
-<table class="table table-sm table-striped table-hover mb-0 stats-table">
-<thead>
-<tr>
-  <th class="stats-metric-col">Metric</th>
-  {% for m in months_data %}
-  <th class="text-end stats-month-col" onclick="location='switch.py?range={{ m.mk }}'" style="cursor:pointer">
-    {{ m.label }}{% if m.coverage_pct < 100 %}<br><span class="small text-muted fw-normal">{{ "%.1f"|format(m.coverage_pct) }}%</span>{% endif %}
-  </th>
-  {% endfor %}
-</tr>
-</thead>
-<tbody>
-<tr class="stats-group"><td colspan="{{ months_data|length + 1 }}" class="fw-semibold small text-uppercase text-muted">Hangar</td></tr>
-<tr>
-  <td class="stats-metric-col ps-3">Avg</td>
-  {% for m in months_data %}
-  <td class="text-end"><span class="unit-f">{{ "%.1f"|format(m.hangar.avg_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.hangar.avg_c) }}&deg;C</span></td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3">Min</td>
-  {% for m in months_data %}
-  <td class="text-end"><span class="unit-f">{{ "%.1f"|format(m.hangar.min_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.hangar.min_c) }}&deg;C</span></td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3">Max</td>
-  {% for m in months_data %}
-  <td class="text-end"><span class="unit-f">{{ "%.1f"|format(m.hangar.max_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.hangar.max_c) }}&deg;C</span></td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3"><span class="unit-f">Hrs &le; 48&deg;F</span><span class="unit-c">Hrs &le; 8.9&deg;C</span></td>
-  {% for m in months_data %}
-  <td class="text-end">{{ "%.1f"|format(m.hangar.cold_hrs) }}</td>
-  {% endfor %}
-</tr>
-{% if months_data|selectattr('outdoor')|list %}
-<tr class="stats-group"><td colspan="{{ months_data|length + 1 }}" class="fw-semibold small text-uppercase text-muted">Outdoor</td></tr>
-<tr>
-  <td class="stats-metric-col ps-3">Avg</td>
-  {% for m in months_data %}
-  <td class="text-end">{% if m.outdoor %}<span class="unit-f">{{ "%.1f"|format(m.outdoor.avg_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.outdoor.avg_c) }}&deg;C</span>{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3">Min</td>
-  {% for m in months_data %}
-  <td class="text-end">{% if m.outdoor %}<span class="unit-f">{{ "%.1f"|format(m.outdoor.min_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.outdoor.min_c) }}&deg;C</span>{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3">Max</td>
-  {% for m in months_data %}
-  <td class="text-end">{% if m.outdoor %}<span class="unit-f">{{ "%.1f"|format(m.outdoor.max_f) }}&deg;F</span><span class="unit-c">{{ "%.1f"|format(m.outdoor.max_c) }}&deg;C</span>{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3"><span class="unit-f">Hrs &le; 48&deg;F</span><span class="unit-c">Hrs &le; 8.9&deg;C</span></td>
-  {% for m in months_data %}
-  <td class="text-end">{% if m.outdoor %}{{ "%.1f"|format(m.outdoor.cold_hrs) }}{% else %}<span class="text-muted">&mdash;</span>{% endif %}</td>
-  {% endfor %}
-</tr>
-{% endif %}
-<tr class="stats-group"><td colspan="{{ months_data|length + 1 }}" class="fw-semibold small text-uppercase text-muted">Runtime</td></tr>
-<tr>
-  <td class="stats-metric-col ps-3">Heater</td>
-  {% for m in months_data %}
-  <td class="text-end">{{ m.heater_str if m.heater_str else '—' }}</td>
-  {% endfor %}
-</tr>
-<tr>
-  <td class="stats-metric-col ps-3">Fan</td>
-  {% for m in months_data %}
-  <td class="text-end">{{ m.fan_str if m.fan_str else '—' }}</td>
-  {% endfor %}
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-{% else %}
-<p class="text-muted m-3 mb-0">No monthly data yet.</p>
-{% endif %}
+<div class="card-body p-0" id="monthly-stats-body">
+  <div class="d-flex justify-content-center align-items-center py-4">
+    <div class="spinner-border spinner-border-sm text-secondary me-2" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+    <span class="text-muted small">Computing monthly stats&hellip;</span>
+  </div>
 </div>
 </div>
 <style>
@@ -283,7 +138,10 @@
 .stats-table th, .stats-table td { white-space: nowrap; }
 </style>
 <script>
-(function() {
+// Init the °F/°C toggle. Idempotent — safe to call multiple times. Has to
+// be re-invoked after the monthly stats fetch swaps in #statsWrap, since
+// the wrap div doesn't exist at initial page load.
+function initStatsUnitToggle() {
   var wrap = document.getElementById('statsWrap');
   if (!wrap) return;
   var saved = null;
@@ -294,13 +152,16 @@
     if (c) c.checked = true;
   }
   document.querySelectorAll('input[name="statsUnit"]').forEach(function(r) {
+    if (r.dataset.unitBound) return;
+    r.dataset.unitBound = '1';
     r.addEventListener('change', function() {
       if (this.value === 'c') wrap.classList.add('unit-c');
       else wrap.classList.remove('unit-c');
       try { localStorage.setItem('statsUnit', this.value); } catch (e) {}
     });
   });
-})();
+}
+initStatsUnitToggle();
 </script>
 {% endif %}
 
@@ -812,6 +673,31 @@ fetch('switch.py?taf=1').then(function(r){return r.text()}).then(function(t){
   t=t.replace(/ (FM|BECMG|TEMPO|PROB\d{2})/g, '\n  $1');
   showWx(document.getElementById('taf'), t, true);
 }).catch(function(){});
+
+// Lazy-load the monthly stats table (~6.7s SQL on Pi Zero W) and the HVAC
+// card body (~3.8s dongle round-trip). Doing them server-side at page load
+// would push TTFB to ~11s; deferred, the page renders in ~1s and these pop
+// in when ready.
+fetch('switch.py?monthly_stats=1').then(function(r){return r.text()}).then(function(html) {
+  var el = document.getElementById('monthly-stats-body');
+  if (el) {
+    el.innerHTML = html;
+    initStatsUnitToggle();
+  }
+}).catch(function() {
+  var el = document.getElementById('monthly-stats-body');
+  if (el) el.innerHTML = '<p class="text-danger m-3 mb-0">Failed to load monthly stats.</p>';
+});
+
+fetch('switch.py?hvac_state=1').then(function(r){return r.json()}).then(function(d) {
+  var body = document.getElementById('hvac-card-body');
+  var header = document.getElementById('hvac-card-header');
+  if (body) body.innerHTML = d.html;
+  if (header) header.className = 'card-header ' + (d.power_on ? 'text-bg-info' : 'text-bg-secondary');
+}).catch(function() {
+  var body = document.getElementById('hvac-card-body');
+  if (body) body.innerHTML = '<p class="text-danger mb-0">Failed to load HVAC state.</p>';
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Moves the two slow page-load operations off the critical path. Main TTFB drops from ~11 s → ~1 s on the Pi Zero W.
- The monthly stats table and the HVAC card now render Bootstrap spinners initially, and JS-fetches the content after page load.
- **Do not auto-merge.** Code paths verified end-to-end on the Pi (helper runs in 6.4 s as expected, both partials parse/render, switch.py syntax-clean), but the spinner-then-content visual swap and the header-color toggle on the HVAC card need eyeballing after deploy.

## Why
Profiled the main render on the Pi after you correctly called out the MTU theory was nonsense:

| Step | Time |
|------|------|
| `query_batch_stats(13mo)` (per-month SQL) | **6.7 s** |
| `hvac.get_state()` (dongle round-trip) | **3.8 s** |
| chart aggregation | 0.07 s |
| door detection (PR #22) | 0.05 s |
| everything else | <0.2 s |

Door detection was 5× faster than chart aggregation — wasn't the issue. The real cost was the per-month stats scan and the dongle network call, both of which serialized on the main render path.

## Approach
* Extract the monthly stats table → `templates/_monthly_stats.html`. No markup change, just lifted into a partial.
* Extract the HVAC card body → `templates/_hvac_card.html`. Same.
* New `_compute_months_data(conn)` helper in `switch.py` — same logic, now reusable.
* Two new early-exit endpoints:
  * `?monthly_stats=1` → partial HTML for the table
  * `?hvac_state=1` → JSON `{power_on: bool, html: "..."}` so the JS can both swap the body and toggle the header class (info vs. secondary)
* Main render skips both fetches. `index.html` shows a `spinner-border` inside each card body.
* Two new `fetch()` calls at the bottom of `index.html` next to the existing METAR/TAF fetches — same pattern.
* The °F/°C unit toggle now lives inside `initStatsUnitToggle()`, re-invoked after the table swap so its event handlers bind to the freshly-injected DOM.

## Failure modes
* Endpoint 5xx / timeout → the spinner is replaced with a small red `Failed to load X` message; the rest of the page is unaffected.
* JS disabled → the spinners stay forever. Acceptable for an internal dashboard.
* The HVAC `Apply` form submission still works exactly as before — it's plain GET with query-string params, the form is in the lazy-loaded HTML now but submits to the same endpoint.

## Test plan after deploy
- [ ] Open the dashboard. Page should appear in ~1 s with spinners in the HVAC card and the Monthly Statistics card body
- [ ] Within ~7 s the monthly stats table populates (6.7 s SQL scan)
- [ ] Within ~4 s the HVAC card populates with current state, header color flips to teal/info if HVAC is on, stays grey if off
- [ ] Toggle °F/°C — table values flip correctly
- [ ] Submit the HVAC Apply form — should redirect and reload as before
- [ ] Check that "Add Schedule" form's HVAC dropdowns still populate (uses `hvac_modes`/`hvac_fans` passed at main render)

## What I couldn't verify
I haven't deployed and watched the spinner pop into actual content in a browser. The plumbing is verified server-side; the JS-side swap is uneyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)