### PR TITLE
fix(wifi-bridge): quiet hostapd to keep log2ram from filling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ The original BCD-vs-BINARY format question on `ac_total_kwh` is **resolved**, bu
 - **Single-radio AP+STA shares one channel.** `AP_CHAN` in the install script must match the hangar WiFi's current channel; hostapd refuses to start on a mismatch with "Could not set channel". If the hangar router roams channels, pin it.
 - **Files written by the script:**
   - `/etc/systemd/system/uap0.service` — creates the `uap0` virtual __ap interface on `wlan0`, gives it `192.168.50.1/24`
-  - `/etc/hostapd/hostapd.conf` — WPA2-PSK on `uap0`, channel hard-coded
+  - `/etc/hostapd/hostapd.conf` — WPA2-PSK on `uap0`, channel hard-coded, `logger_*_level=4` (warning+) to suppress per-association info noise — the Midea dongle keepalive cycles uap0 every ~30s and at default level 2 that produces thousands of lines/day filling log2ram's 128M tmpfs (resolved 2026-05-09)
   - `/etc/dnsmasq.d/uap0.conf` — DHCP `192.168.50.50–.150` on `uap0` only (`bind-interfaces` keeps it off `wlan0`)
   - `/etc/NetworkManager/conf.d/uap0-unmanaged.conf` (Bookworm) or `denyinterfaces uap0` in `/etc/dhcpcd.conf` (Bullseye) — keeps the system network manager from fighting hostapd over `uap0`
   - iptables MASQUERADE on `wlan0` + FORWARD rules, persisted via `iptables-persistent` / `netfilter-persistent`

--- a/scripts/setup-wifi-bridge.sh
+++ b/scripts/setup-wifi-bridge.sh
@@ -69,6 +69,9 @@ WantedBy=multi-user.target
 EOF
 
 echo "Writing /etc/hostapd/hostapd.conf..."
+# logger_*_level=4 (warning+) suppresses per-association info noise. The Midea
+# dongle keepalive cycles uap0 every ~30s; at default level 2 (info) that's
+# thousands of lines/day filling log2ram's 128M tmpfs.
 cat > /etc/hostapd/hostapd.conf <<EOF
 interface=uap0
 driver=nl80211
@@ -82,6 +85,10 @@ wpa=2
 wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 wpa_passphrase=${AP_PASS}
+logger_syslog=-1
+logger_syslog_level=4
+logger_stdout=-1
+logger_stdout_level=4
 EOF
 sed -i 's|^#\?DAEMON_CONF=.*|DAEMON_CONF="/etc/hostapd/hostapd.conf"|' /etc/default/hostapd
 


### PR DESCRIPTION
## Summary

The Pi's `/var/log` (log2ram tmpfs, 128M) hit **100% full**. The Midea HVAC dongle is flap-cycling on `uap0` every ~30 seconds — clean associate → ~31s → disassociate → ~3s → re-associate — and at hostapd's default info level that produces ~3900 `hostapd: uap0:` lines/day across syslog and the journal. Combined with 1748 stale `*.journal~` tombstones from a prior journald hiccup, the tmpfs filled.

This PR adds `logger_syslog_level=4` and `logger_stdout_level=4` (warning+) to the hostapd config so per-association info noise stops being written. The flap itself is a separate concern (likely dongle keepalive / power-save) — not addressed here.

Already done out-of-band on the Pi (matches what the script will write on a fresh install):
- Vacuumed journal `--vacuum-size=40M` (freed 73M of archived journals)
- Deleted 1748 `*.journal~` tombstones
- Force-rotated logs (`logrotate -f`)
- Tightened journal `SystemMaxUse=50M` / `RuntimeMaxUse=50M` in `/etc/systemd/journald.conf` (system-wide; not part of the WiFi bridge installer scope, kept it Pi-side)
- Restarted hostapd + systemd-journald

`/var/log` went from 100% (128M used) → **63% (81M used)** post-fix; the journal alone went 114M → ~50M and is now capped. Dongle still associated to `uap0` after the hostapd restart (`iw dev uap0 station dump` confirms 1s inactivity).

CLAUDE.md updated with a one-line note explaining the new logger settings (so future-me doesn't re-derive why they're there).

## Test plan
- [x] hostapd restarts cleanly with new config
- [x] Dongle re-associates to uap0 after restart (verified via `iw dev uap0 station dump`)
- [x] No `STA … associated/disassociated` lines in `journalctl -u hostapd` since restart
- [x] `/var/log` fill drops back below 100%
- [ ] Re-run `scripts/setup-wifi-bridge.sh` end-to-end on a clean Pi to confirm the new logger lines land in `/etc/hostapd/hostapd.conf` (deferred — would require reflashing)
- [ ] Watch `/var/log` fill % over the next week to confirm steady-state stays well under cap

## Out of scope
- The dongle flap itself (root cause of the noise). Behaves like an idle/keepalive timeout, not the BCM43438 AP+STA wedge documented in CLAUDE.md. Worth separate investigation if it correlates with HVAC reachability gaps; for now the fix is to stop logging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)