### PR TITLE
fix(hvac): chown cache to :www-data so WSGI applies update the UI immediately

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,34 @@ The dongle being physically broken or "stuck and needing a power cycle" has **ne
 
 **The 2026-05-09 incident in one sentence so future-us has a reference point:** dongle appeared "wedged and reconnecting every 30s, needs power cycle"; actual cause was UFW silently dropping the dongle's DHCPDISCOVERs (`ufw-after-input` rule on `udp dpt:67`); fix was `ufw reload`; misdiagnosis would have cost a hangar trip to power-cycle a perfectly healthy dongle.
 
+## Diagnosing "HVAC Apply doesn't stick" / UI shows stale state after clicking Apply
+
+Form submits, browser redirects, status card stays the same. The dongle and msmart-ng are almost certainly fine — the unit DID switch. The bug is cache visibility, and it has one classic cause on this stack.
+
+**One-command diagnostic:** `sudo ls -la /run/heater-hvac.json`
+- `root:www-data` mode 664 → both sides can write → bug not present, look elsewhere
+- `root:root` mode 664 → WSGI (www-data) can't update the cache → bug present
+
+**Cross-check the unit actually changed mode:** the per-minute readings in `/run/heater.db` are written by `log_temp.py` as root and don't suffer this bug.
+```bash
+sudo python3 -c "import sqlite3; \
+  [print(r) for r in sqlite3.connect('/run/heater.db').execute( \
+   \"SELECT datetime(epoch,'unixepoch','-6 hours'), ac_state, ac_power_w \
+    FROM readings ORDER BY epoch DESC LIMIT 10\")]"
+```
+If `ac_state` flipped (1=heat/freeze → 2=cool, etc.) within 1–2 minutes of the Apply click, the unit accepted the change and only the cache is wrong.
+
+**Mechanism.** `log_temp.py` runs as root via cron, `switch.py` runs as `www-data` via mod_wsgi. Both write `/run/heater-hvac.json`. If root creates the file first at boot, it's `root:root` mode 664 and `www-data` has no group write. Every WSGI `set_state` after that sends the SetState to the dongle successfully *(the unit DOES switch)* but `_write_cache` hits a `PermissionError` that the inner `try/except OSError` swallows. The cache then keeps showing the previous root poll until the next cron tick (≤60s) reads the unit and overwrites with the truth — and the `commanded` view (which only `set_state` writes) stays `null` indefinitely.
+
+**Fix.** `hvac.py:_write_cache` chowns the file to `:www-data` after every successful write so both sides can write. The file lives in tmpfs so the bug returns on every reboot until the fix is deployed. One-shot manual recovery on a stuck Pi: `sudo chown root:www-data /run/heater-hvac.json` (good until next reboot).
+
+**Anti-patterns to skip.** Each of these was chased before getting to the cache-perms answer:
+- *"The dongle is rejecting the FP→Cool transition"* — easy to suspect because LAN-FP is known to be quirky on this Durastar. But the per-minute log proves the unit transitioned; the cross-check above settles it in seconds.
+- *"`set_state` is exception-failing silently"* — the outer `except Exception: return False` only catches `_apply()` errors. `_write_cache`'s `OSError` is caught *inside* the function and never reaches the outer handler, so the function returns `True` while the cache is unchanged.
+- *"User is clicking Freeze Prevention preset by accident"* — Apache access log disambiguates instantly: grep for `hvac_apply=1` and read the actual query string.
+
+**The 2026-05-15 incident in one sentence:** Apply (Cool/72°F) clicked 3 times, UI kept showing Freeze/61°F; per-minute log proved the unit transitioned to Cool within 30s of the first click; cache was owned `root:root` so WSGI couldn't update it; fix was a chown in `_write_cache`.
+
 ## HVAC module specifics (`hvac.py`)
 - **Source of truth for the hangar climate.** All Durastar/Midea code lives here; nothing else imports `msmart`.
 - **Lazy import:** `import msmart` happens only inside helper functions, so the WSGI app and cron jobs boot fine on a Pi that hasn't run `pip install msmart-ng` yet. `is_configured()` checks `.env` keys without ever touching the network.

--- a/hvac.py
+++ b/hvac.py
@@ -18,12 +18,22 @@ The UI shows reported by default; commanded is surfaced only when they differ
 """
 
 import asyncio
+import grp
 import json
 import os
 from datetime import datetime
 from pathlib import Path
 
 import config
+
+# log_temp.py (root, cron) and switch.py (www-data, WSGI) both rewrite the
+# HVAC cache. Without a shared group, whichever process touches it first
+# locks the other out — and every silently-failed WSGI write left the UI
+# showing stale state for up to 60s after every Apply click. See _write_cache.
+try:
+    _WWW_DATA_GID = grp.getgrnam("www-data").gr_gid
+except KeyError:
+    _WWW_DATA_GID = None
 
 # ---------------------------------------------------------------------------
 # Paths and constants
@@ -212,6 +222,11 @@ def _write_cache(cache):
         HVAC_CACHE.parent.mkdir(parents=True, exist_ok=True)
         HVAC_CACHE.write_text(json.dumps(cache))
         os.chmod(str(HVAC_CACHE), 0o664)
+        if _WWW_DATA_GID is not None:
+            try:
+                os.chown(str(HVAC_CACHE), -1, _WWW_DATA_GID)
+            except (OSError, PermissionError):
+                pass
     except OSError:
         pass
 


### PR DESCRIPTION
## Summary
- `/run/heater-hvac.json` was being created `root:root` mode 664 by `log_temp.py`'s cron, leaving `www-data` (Apache WSGI) unable to update it. Every `set_state` apply succeeded at the dongle but the cache write silently failed inside `_write_cache`'s `try/except OSError` — so the UI kept showing the previous root-poll until the next minute tick, looking like "Apply didn't stick."
- Fix: `hvac.py:_write_cache` now `chown(-1, www-data)` after writing, so the file is `root:www-data` mode 664 and both processes can write. The `os.chown` is wrapped in a `PermissionError` swallow for the www-data path (it owns the file once root has chowned, so it doesn't need to chown again).
- Adds a "Diagnosing 'HVAC Apply doesn't stick'" playbook to `CLAUDE.md` with the one-command diagnostic (`sudo ls -la /run/heater-hvac.json`), the per-minute-log cross-check that confirms the unit actually transitioned, and the three anti-patterns we already chased (FP rejection, `set_state` exception-failing, wrong-button click).

## The 2026-05-15 incident (one sentence)
Cool/72°F Apply clicked 3 times, UI kept showing Freeze/61°F; per-minute log proved the unit transitioned to Cool within 30s of the first click; cache was owned `root:root` so WSGI couldn't update it; fix is the chown.

## Verification done live on the Pi
- Confirmed cache was `root:root` mode 664.
- Confirmed `sudo -u www-data python3 -c 'Path("/run/heater-hvac.json").write_text(...)'` returns `PermissionError [Errno 13] Permission denied`.
- One-shot `sudo chown root:www-data /run/heater-hvac.json` → same write as www-data now succeeds.
- Confirmed per-minute readings table showed the actual unit transition (Freeze→Cool at 09:07:05, 30s after the first Apply at 09:06:34), proving the dongle and msmart-ng were fine all along.

## Test plan
- [ ] After deploy + ≤1 cron tick: `sudo ls -la /run/heater-hvac.json` shows `root:www-data` mode 664.
- [ ] Click Apply with a state change on the HVAC card; the UI status header updates within the redirect (no waiting for next cron tick).
- [ ] `sudo cat /run/heater-hvac.json | python3 -m json.tool` shows a non-null `commanded` view after the Apply.
- [ ] Reboot the Pi (next planned reboot) and verify the fix survives — the chown is reapplied on every `_write_cache` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)