### PR TITLE
fix(chart): show HVAC watts in the chart tooltip

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -308,6 +308,16 @@ function buildRangeData(data, ranges) {
 }
 var heaterData = buildRangeData(data, heaterRanges);
 var fanData = buildRangeData(data, fanRanges);
+// Align sparse powerData (only buckets above the 200W threshold) to data's
+// x-values with null in the gaps. Chart.js tooltip.mode='index' looks items
+// up by array index across datasets, so a sparse dataset misses tooltips
+// at the very x positions where it does have a point. Heater/fan get the
+// same treatment via buildRangeData above.
+var powerByX = {};
+powerData.forEach(function(p) { powerByX[p.x] = p.y; });
+var powerDataAligned = data.map(function(d) {
+  return { x: d.x, y: powerByX[d.x] !== undefined ? powerByX[d.x] : null };
+});
 // Inline cold-band plugin: replaces chartjs-plugin-annotation (~12 KB) for
 // the single use case of drawing orange boxes over cold-temp ranges.
 var coldBandPlugin = {
@@ -399,7 +409,7 @@ if (data.length > 0) {
         // gaps render as line breaks. pointRadius is small but non-zero so
         // isolated single-minute cycles still show as dots when they don't
         // have neighbors to form a line segment.
-        data: powerData,
+        data: powerDataAligned,
         borderColor: 'rgb(168, 85, 247)',
         backgroundColor: 'rgb(168, 85, 247)',
         fill: false,


### PR DESCRIPTION
## Summary
- Chart tooltip wasn't showing the purple HVAC-watts line value, even when hovering directly over a visible compressor spike (see screenshot from this morning at 09:37 — Hangar/Ambient shown, HVAC W missing).
- Root cause: `interaction.mode: 'index'` resolves tooltips by **array index across datasets**. `powerData` is intentionally sparse (only buckets where `ac_power_w > 200W`), so `powerData[i]` rarely lines up with `data[i]` (dense, one per bucket). Tooltip filter then drops it as undefined.
- Fix: mirror the heater/fan path. Build a dense `powerDataAligned` from `data`'s x-values with `null` in the gaps. The existing `tooltip.filter` already rejects nulls, and `spanGaps: false` keeps the line breaks visually identical.
- Ambient was a near-miss for the same bug — works only because Open-Meteo fills nearly every 15-min bucket. Worth knowing if ambient ever goes sparse.

Server-side `power_data` JSON stays compact (no nulls over the wire); the densification happens client-side at chart-build time.

## Test plan
- [ ] Open the chart, hover over a known compressor spike (purple line) — tooltip should now include `HVAC: NNN W` alongside Hangar and Ambient.
- [ ] Hover between spikes — tooltip should still show Hangar + Ambient only (no spurious `HVAC: 0 W`).
- [ ] 1d / 7d / 30d / monthly all still render the purple line correctly with breaks intact.
- [ ] Heater/fan tooltip labels ("Heater on" / "Fan on") unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)