### PR TITLE
feat(display): add OLED dashboard renderer + systemd service

### DIFF
--- a/display.py
+++ b/display.py
@@ -1,0 +1,388 @@
+"""
+display.py — Renderer for the hangar Pi's 3.2" ILI9341 SPI dashboard.
+
+Produces a 320x240 PIL.Image from a state dict. Pushed to the physical display
+by display_loop.py (driven via luma.lcd over SPI). Distinct from switch.py's
+web UI — both surface the same underlying data, but the OLED is glance-only
+and emphasises different things: heater state + tappable toggle, multi-stage
+FlashAir status, schedule preview. Hangar temp / HVAC are demoted to a footer
+since they're redundant with the HVAC remote and wall unit.
+
+State dict shape:
+    {
+      "heater": {"on": bool, "next_event": {action, epoch, label} | None},
+      "flashair": {
+          "epoch": int,
+          "stage": "idle"|"scanning"|"downloading"|"uploading"|"error",
+          "current_ssid": str | None,
+          "files_done": int, "files_total": int,
+          "current_file": str | None,
+          "last_sync_epoch": int | None, "last_sync_files_n": int,
+          "stale": bool,
+      } | None,
+      "hvac": {"mode": str, "target_f": float|None, "power_w": int} | None,
+      "hangar_f": float | None,
+      "now_epoch": int,
+    }
+
+PIL is a lazy import so this module can be imported on a Pi that hasn't
+installed Pillow yet (matches hvac.py's msmart pattern).
+"""
+
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WIDTH  = 320
+HEIGHT = 240
+
+# Sync within this window renders as the bright "done" treatment; older becomes
+# a muted "idle" line. 10 min is long enough to catch the user's post-flight
+# walk to the hangar door but short enough that "done" feels meaningful.
+DONE_WINDOW_SECS = 600
+
+# Past this, the "updated Xs ago" indicator in the FlashAir header turns red —
+# the display can't see fresh status from flashair-sync (the service itself
+# may have stopped, the cache file may be missing).
+STALE_AFTER_SECS = 120
+
+COLOR = {
+    "bg":              (10, 10, 12),
+    "fg":              (240, 240, 240),
+    "dim":             (140, 140, 145),
+    "very_dim":        (90, 92, 98),
+    "rule":            (50, 55, 65),
+    "heater_on_bg":    (185, 35, 50),
+    "heater_on_fg":    (255, 255, 255),
+    "heater_off_bg":   (40, 42, 48),
+    "heater_off_fg":   (190, 190, 195),
+    "heater_border":   (90, 95, 105),
+    "sched":           (170, 175, 185),
+    "flash_active":    (255, 195, 90),
+    "flash_done":      (110, 220, 130),
+    "flash_idle":      (140, 140, 145),
+    "flash_error":     (240, 95, 80),
+    "flash_stale":     (240, 95, 80),
+    "ssid_hangar":     (140, 145, 155),
+    "ssid_flashair":   (255, 195, 90),
+    "ssid_none":       (240, 95, 80),
+    "hvac_heat":       (240, 100, 80),
+    "hvac_cool":       (90, 165, 240),
+    "hvac_freeze":     (255, 180, 60),
+}
+
+# Font search paths. Pi/Debian first (the deployment target), macOS second
+# (for local mockup generation during development). PIL's default bitmap font
+# is the last-resort fallback so this module always renders something.
+_SANS_REG = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+]
+_SANS_BOLD = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+]
+_MONO = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+    "/System/Library/Fonts/Menlo.ttc",
+]
+
+
+# ---------------------------------------------------------------------------
+# Font loading — lazy, cached per (path, size)
+# ---------------------------------------------------------------------------
+
+_font_cache = {}
+
+
+def _font(paths, size):
+    from PIL import ImageFont
+    key = (tuple(paths), size)
+    if key in _font_cache:
+        return _font_cache[key]
+    font = None
+    for p in paths:
+        if Path(p).exists():
+            try:
+                font = ImageFont.truetype(p, size)
+                break
+            except OSError:
+                continue
+    if font is None:
+        font = ImageFont.load_default()
+    _font_cache[key] = font
+    return font
+
+
+# ---------------------------------------------------------------------------
+# Format helpers
+# ---------------------------------------------------------------------------
+
+def fmt_age(secs):
+    if secs is None:
+        return "—"
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86400:
+        return f"{secs // 3600}h{(secs % 3600) // 60:02d}m"
+    return f"{secs // 86400}d"
+
+
+def fmt_until(secs):
+    if secs is None or secs < 0:
+        return ""
+    if secs < 3600:
+        return f"in {secs // 60}m"
+    h = secs // 3600
+    m = (secs % 3600) // 60
+    return f"in {h}h{m:02d}m"
+
+
+# ---------------------------------------------------------------------------
+# FlashAir status → renderable text + visual treatment
+# ---------------------------------------------------------------------------
+
+def flashair_lines(fa):
+    """
+    Returns (headline, color, sub, has_progress_bar) for the FlashAir section.
+    `fa` may be None (FlashAir not configured) — caller skips rendering in that case.
+    """
+    if fa is None:
+        return ("not configured", COLOR["flash_idle"], None, False)
+
+    if fa.get("stale"):
+        return ("sync service down", COLOR["flash_stale"], "go look at the problem", False)
+
+    stage = fa.get("stage", "idle")
+    fd = fa.get("files_done", 0)
+    ft = fa.get("files_total", 0)
+    cf = fa.get("current_file")
+    last = fa.get("last_sync_epoch")
+    now = fa.get("epoch", 0)
+    age_since_sync = (now - last) if last else None
+    n = fa.get("last_sync_files_n", 0)
+    unit = "file" if n == 1 else "files"
+
+    if stage == "idle":
+        if last is None:
+            return ("idle  (no sync yet)", COLOR["flash_idle"], None, False)
+        if age_since_sync < DONE_WINDOW_SECS:
+            return (f"done — {n} {unit}, {fmt_age(age_since_sync)} ago",
+                    COLOR["flash_done"], None, False)
+        return (f"idle — last sync {n} {unit}, {fmt_age(age_since_sync)} ago",
+                COLOR["flash_idle"], None, False)
+    if stage == "scanning":
+        return ("scanning card", COLOR["flash_active"], None, False)
+    if stage == "downloading":
+        return (f"downloading from card  {fd} of {ft}",
+                COLOR["flash_active"], cf, True)
+    if stage == "uploading":
+        return (f"uploading to remote  {fd} of {ft}",
+                COLOR["flash_active"], cf, True)
+    if stage == "error":
+        return ("error", COLOR["flash_error"], "go look at the problem", False)
+    # Unknown stage value — render literally so it's visible during dev.
+    return (stage, COLOR["fg"], None, False)
+
+
+def ssid_color(ssid, flashair_pattern=None):
+    """
+    Pick a color for the SSID label.
+
+    `flashair_pattern` is an env-configurable substring; if the SSID contains
+    it (case-insensitive), the SSID renders as 'active' (amber). Anything else
+    is 'normal' (grey). A null SSID renders red — wifi is down entirely.
+    """
+    if ssid is None:
+        return COLOR["ssid_none"]
+    if flashair_pattern and flashair_pattern.lower() in ssid.lower():
+        return COLOR["ssid_flashair"]
+    return COLOR["ssid_hangar"]
+
+
+def hvac_label(hvac):
+    """Returns (label, color) for the HVAC footer, or (None, None) if HVAC is off / not configured."""
+    if hvac is None:
+        return (None, None)
+    mode = hvac.get("mode", "off")
+    target = hvac.get("target_f")
+    pw = hvac.get("power_w", 0)
+    color = {
+        "heat":   COLOR["hvac_heat"],
+        "cool":   COLOR["hvac_cool"],
+        "freeze": COLOR["hvac_freeze"],
+        "off":    COLOR["dim"],
+    }.get(mode, COLOR["fg"])
+    label = f"{mode.upper()}→{target:.0f}°F · {pw}W" if target else f"{mode.upper()} · {pw}W"
+    return (label, color)
+
+
+# ---------------------------------------------------------------------------
+# Main render entry point
+# ---------------------------------------------------------------------------
+
+# Geometry for the heater touch button — exposed so the touch handler in
+# display_loop.py can hit-test taps against the same rectangle.
+HEATER_BUTTON_RECT = (10, 22, 150, 92)  # (x1, y1, x2, y2)
+
+
+def render(state, flashair_ssid_pattern=None):
+    """
+    Build the 320x240 dashboard image. `state` shape documented in module
+    docstring. `flashair_ssid_pattern` is the .env-configured substring used
+    to color SSIDs that match (e.g. "flashair") as active.
+    """
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (WIDTH, HEIGHT), COLOR["bg"])
+    d = ImageDraw.Draw(img)
+
+    f_label      = _font(_SANS_REG, 12)
+    f_btn        = _font(_SANS_BOLD, 36)
+    f_sched      = _font(_SANS_REG, 14)
+    f_sched_sm   = _font(_SANS_REG, 11)
+    f_flash_head = _font(_SANS_BOLD, 18)
+    f_mono_sm    = _font(_MONO, 11)
+    f_footer     = _font(_SANS_REG, 13)
+    f_tiny       = _font(_SANS_REG, 10)
+
+    now = state.get("now_epoch", 0)
+
+    # ----- Heater section --------------------------------------------------
+    d.text((10, 6), "ENGINE HEATER", fill=COLOR["dim"], font=f_label)
+
+    heater = state.get("heater", {}) or {}
+    h_on = bool(heater.get("on"))
+    btn_bg = COLOR["heater_on_bg"] if h_on else COLOR["heater_off_bg"]
+    btn_fg = COLOR["heater_on_fg"] if h_on else COLOR["heater_off_fg"]
+    x1, y1, x2, y2 = HEATER_BUTTON_RECT
+    d.rectangle([(x1, y1), (x2, y2)], fill=btn_bg,
+                outline=COLOR["heater_border"], width=2)
+    text = "ON" if h_on else "OFF"
+    bbox = d.textbbox((0, 0), text, font=f_btn)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    d.text((x1 + (x2 - x1 - tw) / 2, y1 + (y2 - y1 - th) / 2),
+           text, fill=btn_fg, font=f_btn)
+
+    next_evt = heater.get("next_event")
+    d.text((165, 22), "Schedule", fill=COLOR["dim"], font=f_label)
+    if next_evt is None:
+        d.text((165, 40), "no events", fill=COLOR["dim"], font=f_sched)
+    else:
+        d.text((165, 40), f"→ {next_evt['label']}", fill=COLOR["sched"], font=f_sched)
+        until = fmt_until(next_evt["epoch"] - now)
+        if until:
+            d.text((165, 60), until, fill=COLOR["dim"], font=f_sched_sm)
+
+    d.line([(10, 105), (310, 105)], fill=COLOR["rule"], width=1)
+
+    # ----- FlashAir section ------------------------------------------------
+    d.text((10, 113), "FLASHAIR", fill=COLOR["dim"], font=f_label)
+
+    fa = state.get("flashair")
+    if fa is not None:
+        # SSID indicator: only rendered when the contract carries `current_ssid`.
+        # Absent key (v0 contract) → suppress indicator. None value (v1, wifi
+        # actually down) → "no wifi" in red.
+        if "current_ssid" in fa:
+            ssid = fa["current_ssid"]
+            ssid_label = f'on "{ssid}"' if ssid else "no wifi"
+            d.text((68, 113), "·", fill=COLOR["very_dim"], font=f_label)
+            d.text((78, 113), ssid_label,
+                   fill=ssid_color(ssid, flashair_ssid_pattern), font=f_label)
+
+        age = now - fa.get("epoch", now)
+        fresh_text = f"updated {fmt_age(age)} ago"
+        fresh_color = COLOR["flash_stale"] if age > STALE_AFTER_SECS else COLOR["very_dim"]
+        bbox = d.textbbox((0, 0), fresh_text, font=f_tiny)
+        fw = bbox[2] - bbox[0]
+        d.text((WIDTH - 10 - fw, 114), fresh_text, fill=fresh_color, font=f_tiny)
+
+        headline, hcolor, sub, has_bar = flashair_lines(fa)
+        d.text((10, 130), headline, fill=hcolor, font=f_flash_head)
+        if sub:
+            max_chars = 38
+            sub_display = sub if len(sub) <= max_chars else sub[: max_chars - 1] + "…"
+            d.text((10, 158), sub_display, fill=COLOR["dim"], font=f_mono_sm)
+
+        if has_bar:
+            fd = fa.get("files_done", 0)
+            ft = max(fa.get("files_total", 1), 1)
+            frac = max(0.0, min(1.0, fd / ft))
+            d.rectangle([(10, 178), (310, 188)], outline=COLOR["rule"], width=1)
+            d.rectangle([(11, 179), (11 + int(298 * frac), 187)], fill=COLOR["flash_active"])
+    else:
+        d.text((10, 130), "not configured", fill=COLOR["flash_idle"], font=f_flash_head)
+
+    d.line([(10, 200), (310, 200)], fill=COLOR["rule"], width=1)
+
+    # ----- HVAC + hangar temp footer --------------------------------------
+    label, color = hvac_label(state.get("hvac"))
+    if label is not None:
+        d.text((10, 213), "HVAC", fill=COLOR["dim"], font=f_label)
+        d.text((50, 211), label, fill=color, font=f_footer)
+    hangar_f = state.get("hangar_f")
+    if hangar_f is not None:
+        d.text((230, 213), f"Hangar {hangar_f:.0f}°F", fill=COLOR["dim"], font=f_footer)
+
+    return img
+
+
+# ---------------------------------------------------------------------------
+# CLI — generate mockup PNGs for design review without needing the display
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import time
+
+    NOW = int(time.time())
+
+    def fa_state(stage, **kw):
+        out = {
+            "epoch": NOW - 4,
+            "stage": stage,
+            "current_ssid": "Hangar-WiFi",
+            "files_done": 0, "files_total": 0,
+            "current_file": None,
+            "last_sync_epoch": NOW - 3600,
+            "last_sync_files_n": 12,
+            "stale": False,
+        }
+        out.update(kw)
+        return out
+
+    BASE = {
+        "now_epoch": NOW,
+        "heater":   {"on": False, "next_event": None},
+        "hvac":     {"mode": "freeze", "target_f": 46, "power_w": 146},
+        "hangar_f": 47.1,
+    }
+
+    states = {
+        "idle_done":       {**BASE, "flashair": fa_state("idle", last_sync_epoch=NOW - 90)},
+        "downloading":     {**BASE, "flashair": fa_state("downloading",
+                                                        current_ssid="FlashAir-Card",
+                                                        files_done=3, files_total=7,
+                                                        current_file="log_20260521_134505_KLMO.csv")},
+        "uploading":       {**BASE, "flashair": fa_state("uploading",
+                                                        files_done=5, files_total=7,
+                                                        current_file="log_20260521_134505_KLMO.csv")},
+        "sync_down":       {**BASE, "flashair": fa_state("idle", stale=True, epoch=NOW - 600)},
+        "no_flashair":     {**BASE, "flashair": None},
+        "heater_on":       {**BASE, "flashair": fa_state("idle", last_sync_epoch=NOW - 60),
+                            "heater": {"on": True,
+                                       "next_event": {"action": "off", "epoch": NOW + 4320,
+                                                      "label": "OFF at 7:30 AM"}}},
+    }
+
+    out_dir = os.environ.get("DISPLAY_PREVIEW_DIR", "/tmp")
+    for name, st in states.items():
+        img = render(st, flashair_ssid_pattern="flashair")
+        path = f"{out_dir}/display-preview-{name}.png"
+        img.resize((WIDTH * 2, HEIGHT * 2)).save(path)
+        print(path)

--- a/display.service
+++ b/display.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hangar dashboard — drives the 3.2" SPI display
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/usr/lib/cgi-bin/remote-switch
+ExecStart=/usr/bin/python3 /usr/lib/cgi-bin/remote-switch/display_loop.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/display_loop.py
+++ b/display_loop.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+display_loop.py — Drives the hangar Pi's 3.2" ILI9341 SPI dashboard.
+
+Reads display_state.get_state() every UPDATE_INTERVAL_SECS, renders it via
+display.render(), and pushes the result to the ILI9341 panel via luma.lcd
+on SPI0.
+
+Runs under systemd (see display.service). Touch handling is intentionally
+deferred to a follow-up — this loop is render-only, so the rest of the path
+can land + be verified on hardware before XPT2046 calibration adds a moving
+part. The button geometry already lives in display.HEATER_BUTTON_RECT for
+the touch handler to consume when it lands.
+
+CLI flags:
+    --once          render one frame, push, exit. Useful for spot checks.
+    --dry-run       skip SPI init; write the render to /tmp/display-current.png
+                    each iteration. Sets if DISPLAY_DRY_RUN=1 is in env too.
+"""
+
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+# Allow systemd to invoke us from any working directory.
+sys.path.insert(0, str(Path(__file__).parent))
+
+import config           # noqa: E402  (path-modifying import above)
+import display          # noqa: E402
+import display_state    # noqa: E402
+
+
+UPDATE_INTERVAL_SECS = 5
+DRY_RUN_OUT          = Path("/tmp/display-current.png")
+
+# ILI9341 control pins. Match display.py's pin map and the wiring docs.
+GPIO_DC  = 24
+GPIO_RST = 25
+SPI_PORT = 0
+SPI_DEV  = 0   # SPI0 CE0 — the display's chip select (BCM 8)
+
+
+_stop = False
+
+
+def _on_signal(_signum, _frame):
+    global _stop
+    _stop = True
+
+
+def _is_dry_run():
+    return "--dry-run" in sys.argv or os.environ.get("DISPLAY_DRY_RUN") == "1"
+
+
+def _open_device():
+    """Open the ILI9341 over SPI. Lazy import so the module works without luma installed."""
+    from luma.core.interface.serial import spi
+    from luma.lcd.device import ili9341
+
+    serial = spi(port=SPI_PORT, device=SPI_DEV, gpio_DC=GPIO_DC, gpio_RST=GPIO_RST)
+    # rotate=1 → landscape orientation (320 wide × 240 tall). The renderer
+    # produces images in that orientation; rotate=0 would render sideways.
+    return ili9341(serial, rotate=1, width=display.WIDTH, height=display.HEIGHT)
+
+
+def _flashair_ssid_pattern():
+    """Substring used to color a matching SSID as 'active' (amber). Default 'flashair'."""
+    env = config.load_env()
+    return env.get("FLASHAIR_SSID_PATTERN", "flashair").strip() or "flashair"
+
+
+def _push(device, ssid_pattern):
+    """Render one frame and push it. Errors logged, never raised."""
+    try:
+        state = display_state.get_state()
+        img = display.render(state, flashair_ssid_pattern=ssid_pattern)
+    except Exception as e:
+        sys.stderr.write(f"display: state/render failed: {e}\n")
+        return
+
+    try:
+        if device is None:
+            img.save(DRY_RUN_OUT)
+        else:
+            device.display(img)
+    except Exception as e:
+        # Transient SPI hiccups shouldn't kill the loop — systemd Restart handles real crashes.
+        sys.stderr.write(f"display: push failed: {e}\n")
+
+
+def main():
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    device = None if _is_dry_run() else _open_device()
+    ssid_pattern = _flashair_ssid_pattern()
+
+    if "--once" in sys.argv:
+        _push(device, ssid_pattern)
+        if _is_dry_run():
+            print(f"wrote {DRY_RUN_OUT}")
+        return
+
+    while not _stop:
+        _push(device, ssid_pattern)
+        # Sleep in 100ms chunks so SIGTERM (systemctl stop) is responsive.
+        for _ in range(UPDATE_INTERVAL_SECS * 10):
+            if _stop:
+                break
+            time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    main()

--- a/display_state.py
+++ b/display_state.py
@@ -1,0 +1,195 @@
+"""
+display_state.py — Assembles the state dict consumed by display.render().
+
+Reads from the project's existing data sources — no new caches:
+    - /run/heater.db          → latest hangar temp (temp_c)
+    - GPIO 17 sysfs           → live heater state
+    - /var/lib/heater/heater.db.schedules → next heater event
+    - /run/heater-hvac.json   → HVAC reported state (read directly, never
+                                 triggers a dongle round-trip from this path)
+    - /run/heater-flashair.json → multi-stage FlashAir status (written by
+                                   flashair-sync; produced by phase 1 PRs +
+                                   the follow-up contract extension)
+
+Each source is independent — if any one is missing, only that field of the
+state dict goes to None and render() degrades gracefully.
+"""
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from time import time
+
+import config
+import flashair
+import hvac
+
+
+# ---------------------------------------------------------------------------
+# Individual source readers — each catches its own errors and returns None
+# ---------------------------------------------------------------------------
+
+def _latest_temp_c():
+    """Most recent hangar temp from the RAM DB, or None."""
+    try:
+        conn = config.get_ram_db()
+        row = conn.execute(
+            "SELECT temp_c FROM readings ORDER BY epoch DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        if row and row[0] is not None:
+            return float(row[0])
+    except (sqlite3.Error, OSError):
+        pass
+    return None
+
+
+def _heater_on():
+    """True iff the heater GPIO is driven high right now."""
+    try:
+        return config.read_gpio() == "1"
+    except OSError:
+        return False
+
+
+def _fmt_schedule_time(epoch):
+    """7:30 AM / 12:05 PM — strip the leading zero portably (works on Linux + macOS)."""
+    return datetime.fromtimestamp(epoch).strftime("%I:%M %p").lstrip("0")
+
+
+def _next_heater_event(now):
+    """
+    Next upcoming heater schedule, or None.
+
+    Returns shape: {action: "ON"|"OFF", epoch: int, label: str}
+    Matches what display.render() expects in heater.next_event.
+    """
+    try:
+        conn = config.get_db()
+        row = conn.execute(
+            "SELECT execute_epoch, action FROM schedules "
+            "WHERE device = 'heater' AND execute_epoch > ? "
+            "ORDER BY execute_epoch LIMIT 1",
+            (now,),
+        ).fetchone()
+        conn.close()
+    except (sqlite3.Error, OSError):
+        return None
+    if not row:
+        return None
+    epoch, action = int(row[0]), str(row[1])
+    label_action = "ON" if action == "1" else "OFF"
+    return {
+        "action": label_action,
+        "epoch": epoch,
+        "label": f"{label_action} at {_fmt_schedule_time(epoch)}",
+    }
+
+
+def _hvac_summary():
+    """
+    Read the HVAC cache file directly (never triggers a dongle fetch).
+
+    log_temp.py is the canonical place where HVAC gets refreshed (its per-minute
+    cron job calls hvac.state_for_log() → hvac.get_state() which writes the
+    cache). The display loop only reads the cache to avoid 5-second polling of
+    the dongle.
+    """
+    try:
+        data = json.loads(hvac.HVAC_CACHE.read_text())
+    except (OSError, ValueError):
+        return None
+    reported = data.get("reported")
+    if not reported:
+        return None
+    return {
+        "mode":     reported.get("mode", "off"),
+        "target_f": reported.get("target_f"),
+        "power_w":  int(reported.get("power_w") or 0),
+    }
+
+
+def _flashair(now):
+    """
+    Read /run/heater-flashair.json, return the state dict the renderer wants.
+
+    None if the file doesn't exist — render() shows "not configured" in that case.
+
+    Shares the file path + staleness threshold with flashair.py (the web-UI
+    consumer), so both views stay in lock-step if either constant changes.
+
+    Handles two contract generations:
+      v0 (current main):  {epoch, last_sync_epoch, last_sync_files_n,
+                           transferring, current_file}
+      v1 (follow-up PR):  adds stage, current_ssid, files_done, files_total
+
+    On v0 data, stage is inferred from `transferring`. On v1 data, everything
+    comes through as-is. Both render correctly.
+
+    `stale=True` is set here (not in the on-disk JSON) when epoch is too old —
+    that's the signal that flashair-sync itself stopped writing the file.
+    """
+    data = flashair.read_cache()
+    if data is None:
+        return None
+
+    epoch = int(data.get("epoch", 0))
+    if epoch == 0 or now - epoch > flashair.STALE_AFTER_SECS:
+        return {"epoch": epoch, "stale": True}
+
+    out = {
+        "epoch":              epoch,
+        "last_sync_epoch":    data.get("last_sync_epoch"),
+        "last_sync_files_n":  int(data.get("last_sync_files_n", 0)),
+        "current_file":       data.get("current_file"),
+        "stale":              False,
+    }
+
+    if "stage" in data:
+        # v1 contract — full multi-stage info
+        out["stage"]         = data["stage"]
+        out["current_ssid"]  = data.get("current_ssid")   # may be None → "no wifi"
+        out["files_done"]    = int(data.get("files_done", 0))
+        out["files_total"]   = int(data.get("files_total", 0))
+    else:
+        # v0 contract — collapse the boolean into the stage enum.
+        # current_ssid is intentionally omitted: v0 doesn't carry it, and we
+        # want the renderer to suppress the SSID indicator (not show "no wifi"
+        # red, which would imply wifi is actually down).
+        out["stage"]         = "downloading" if data.get("transferring") else "idle"
+        out["files_done"]    = 0
+        out["files_total"]   = 0
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+def _c_to_f(c):
+    return round(c * 9 / 5 + 32, 1) if c is not None else None
+
+
+def get_state():
+    """Build the full state dict for display.render()."""
+    now = int(time())
+    return {
+        "now_epoch": now,
+        "heater": {
+            "on":         _heater_on(),
+            "next_event": _next_heater_event(now),
+        },
+        "flashair": _flashair(now),
+        "hvac":     _hvac_summary(),
+        "hangar_f": _c_to_f(_latest_temp_c()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI — dump the live state to stdout. Handy for ssh-debugging on the Pi.
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print(json.dumps(get_state(), indent=2, default=str))

--- a/docs/display-install.html
+++ b/docs/display-install.html
@@ -1,0 +1,469 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hangar display — install</title>
+  <style>
+    :root {
+      --bg: #0d0e10;
+      --panel: #16181d;
+      --rule: #2a2d33;
+      --fg: #e6e7eb;
+      --fg-dim: #9b9ea6;
+      --fg-very-dim: #6a6d75;
+      --accent: #6ec8ff;
+      --warn: #ffb44a;
+      --bad: #ff6258;
+      --ok: #84d99c;
+      --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 1.5rem;
+      background: var(--bg);
+      color: var(--fg);
+      font: 15px/1.55 var(--sans);
+      max-width: 880px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    h1 {
+      font-size: 1.65rem;
+      margin: 0 0 0.25rem;
+    }
+    h2 {
+      font-size: 1.15rem;
+      margin: 2rem 0 0.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--rule);
+      color: var(--accent);
+    }
+    h3 {
+      font-size: 1rem;
+      margin: 1.25rem 0 0.5rem;
+      color: var(--fg-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .lede {
+      color: var(--fg-dim);
+      margin: 0 0 1.5rem;
+    }
+    code, pre, kbd {
+      font-family: var(--mono);
+      font-size: 0.9em;
+    }
+    code {
+      background: var(--panel);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    pre {
+      background: var(--panel);
+      border: 1px solid var(--rule);
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      overflow-x: auto;
+      margin: 0.5rem 0 1rem;
+    }
+    pre code { background: none; padding: 0; }
+    .step {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.7rem;
+      margin: 0.4rem 0;
+      padding: 0.35rem 0;
+    }
+    .step input[type=checkbox] {
+      flex: 0 0 auto;
+      width: 22px;
+      height: 22px;
+      margin-top: 1px;
+      cursor: pointer;
+      accent-color: var(--ok);
+    }
+    .step-body {
+      flex: 1;
+      min-width: 0;
+    }
+    .step.done .step-body {
+      color: var(--fg-very-dim);
+      text-decoration: line-through;
+    }
+    .step.done pre, .step.done code {
+      opacity: 0.5;
+    }
+    .note {
+      border-left: 3px solid var(--warn);
+      background: var(--panel);
+      padding: 0.65rem 0.9rem;
+      margin: 0.75rem 0;
+      border-radius: 0 4px 4px 0;
+      font-size: 0.93em;
+    }
+    .note.danger { border-left-color: var(--bad); }
+    .note.tip    { border-left-color: var(--accent); }
+    .note strong { color: var(--warn); }
+    .note.danger strong { color: var(--bad); }
+    .note.tip strong    { color: var(--accent); }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0.5rem 0 1rem;
+      font-size: 0.93em;
+    }
+    th, td {
+      border-bottom: 1px solid var(--rule);
+      padding: 0.45rem 0.6rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { color: var(--fg-dim); font-weight: 600; font-size: 0.82em; text-transform: uppercase; letter-spacing: 0.05em; }
+    td code { font-size: 0.95em; }
+    .pinmap td:nth-child(1) { font-weight: 600; }
+    .pinmap td:nth-child(2),
+    .pinmap td:nth-child(3) { font-family: var(--mono); color: var(--accent); }
+    .pinmap tr.power td:nth-child(2),
+    .pinmap tr.power td:nth-child(3) { color: var(--warn); }
+    .pinmap tr.gnd td:nth-child(2),
+    .pinmap tr.gnd td:nth-child(3) { color: var(--fg-dim); }
+    .reset {
+      margin-top: 2.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--rule);
+      text-align: center;
+    }
+    .reset button {
+      background: var(--panel);
+      color: var(--fg-dim);
+      border: 1px solid var(--rule);
+      padding: 0.4rem 0.9rem;
+      border-radius: 4px;
+      font: inherit;
+      font-size: 0.85em;
+      cursor: pointer;
+    }
+    .reset button:hover {
+      background: var(--rule);
+      color: var(--fg);
+    }
+    .progress {
+      position: sticky;
+      top: 0;
+      background: var(--bg);
+      padding: 0.6rem 0;
+      margin: -1.5rem -1.5rem 1.5rem;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+      border-bottom: 1px solid var(--rule);
+      font-size: 0.85em;
+      color: var(--fg-dim);
+      z-index: 10;
+    }
+    .progress-bar {
+      height: 3px;
+      background: var(--rule);
+      border-radius: 2px;
+      margin-top: 0.35rem;
+      overflow: hidden;
+    }
+    .progress-bar > div {
+      height: 100%;
+      background: var(--ok);
+      transition: width 0.3s ease;
+    }
+    @media print {
+      .progress, .reset { display: none; }
+      body { color: black; background: white; max-width: none; }
+      h2 { color: black; border-top-color: #ccc; }
+      h3, .lede { color: #444; }
+      pre, code { background: #f4f4f4; color: black; }
+      .note { background: #fafafa; }
+      .step.done .step-body { text-decoration: none; color: #888; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="progress">
+  <span id="progress-text">0 of 0 steps done</span>
+  <div class="progress-bar"><div id="progress-fill" style="width: 0%"></div></div>
+</div>
+
+<h1>Hangar display — install</h1>
+<p class="lede">
+  Wiring + software cheat-sheet for the 3.2" ILI9341 SPI display on
+  <code>pi.vpn</code>. Check off each step as you go — progress is saved
+  in this browser.
+</p>
+
+<h2>Parts check</h2>
+<div class="step">
+  <input type="checkbox" id="p1">
+  <div class="step-body"><label for="p1"><strong>3.2" ILI9341 SPI display</strong> (Pasotim MSP3218 or equivalent) — 320×240, ILI9341 driver, SPI interface, 3.3V/5V logic.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="p2">
+  <div class="step-body"><label for="p2"><strong>Female-to-female jumper wires</strong> (Dupont, 20cm) — need 8 minimum, get 10+ as spares.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="p3">
+  <div class="step-body"><label for="p3">Display inspected — no bent pins, no damage in transit, PCB markings include "ILI9341" or "MSP3218".</label></div>
+</div>
+
+<h2>Power down before wiring</h2>
+<div class="note danger">
+  <strong>Important:</strong> shut the Pi cleanly before wiring. The Pi's GPIO is not hot-pluggable, and a wiring slip with the Pi powered can fry both ends.
+</div>
+<div class="step">
+  <input type="checkbox" id="d1">
+  <div class="step-body"><label for="d1">SSH in and shut down cleanly.<pre><code>ssh pi.vpn
+sudo systemctl poweroff</code></pre>Wait for the green ACT LED to stop blinking, then unplug power.</label></div>
+</div>
+
+<h2>Wiring</h2>
+<p>Pi Zero W 40-pin header. <strong>All 8 connections to the display use 3.3V logic and 3V3 power</strong> — do <em>not</em> wire VCC to the Pi's 5V rail even though the display says it accepts 5V.</p>
+
+<table class="pinmap">
+  <thead>
+    <tr><th>Display pin</th><th>Pi BCM</th><th>Pi header pin</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr class="power"><td>VCC</td><td>3V3</td><td>1</td><td>Power. Use 3V3, not 5V.</td></tr>
+    <tr class="gnd"><td>GND</td><td>GND</td><td>6</td><td>Any GND pin works (6/9/14/20/25/30/34/39).</td></tr>
+    <tr><td>CS</td><td>BCM 8</td><td>24</td><td>SPI0 CE0 — display chip select.</td></tr>
+    <tr><td>RESET</td><td>BCM 25</td><td>22</td><td>Display reset, driven by luma.lcd at init.</td></tr>
+    <tr><td>DC</td><td>BCM 24</td><td>18</td><td>Data / command select.</td></tr>
+    <tr><td>SDI / MOSI</td><td>BCM 10</td><td>19</td><td>SPI MOSI.</td></tr>
+    <tr><td>SCK</td><td>BCM 11</td><td>23</td><td>SPI clock.</td></tr>
+    <tr class="power"><td>LED</td><td>3V3</td><td>17</td><td>Backlight, always-on. PWM dimming via GPIO is a later option.</td></tr>
+  </tbody>
+</table>
+
+<p>Touch pins on the display (<code>T_CS</code>, <code>T_CLK</code>, <code>T_DIN</code>, <code>T_DO</code>, <code>T_IRQ</code>) and <code>SDO / MISO</code> are <strong>left unconnected</strong> for now — touch handling lands in a follow-up after first-light.</p>
+
+<div class="note tip">
+  <strong>Tip:</strong> use consistent jumper colors so you can trace at a glance — red = 3V3, black = GND, anything else for signals. Verify each jumper end-to-end with a continuity test (or just gently tug) before powering on.
+</div>
+
+<div class="step">
+  <input type="checkbox" id="w1">
+  <div class="step-body"><label for="w1">All 8 wires connected, double-checked against the table above.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="w2">
+  <div class="step-body"><label for="w2">No wires touching adjacent header pins (a misalignment by one pin grounds 3V3 → fry).</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="w3">
+  <div class="step-body"><label for="w3">Pi powered back on. Green ACT LED blinking normally.</label></div>
+</div>
+
+<h2>Enable SPI</h2>
+<p>The Pi's SPI peripheral is off by default. luma.lcd won't work without it.</p>
+<div class="step">
+  <input type="checkbox" id="s1">
+  <div class="step-body"><label for="s1">SSH back in and enable SPI.<pre><code>ssh pi.vpn
+sudo raspi-config nonint do_spi 0</code></pre>That edits <code>/boot/firmware/config.txt</code> (Bookworm) or <code>/boot/config.txt</code> (older) to add <code>dtparam=spi=on</code>.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="s2">
+  <div class="step-body"><label for="s2">Reboot so the SPI overlay loads.<pre><code>sudo reboot</code></pre></label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="s3">
+  <div class="step-body"><label for="s3">Verify SPI is loaded after reboot — <code>spi_bcm2835</code> should appear.<pre><code>ssh pi.vpn
+lsmod | grep spi
+ls /dev/spidev*</code></pre>You should see <code>/dev/spidev0.0</code> and <code>/dev/spidev0.1</code>.</label></div>
+</div>
+
+<h2>Install luma.lcd</h2>
+<div class="step">
+  <input type="checkbox" id="i1">
+  <div class="step-body"><label for="i1">Install the driver. On Bookworm, pip needs the <code>--break-system-packages</code> flag (or use a venv — this project doesn't, so match the existing convention).<pre><code>sudo pip install luma.lcd --break-system-packages</code></pre></label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="i2">
+  <div class="step-body"><label for="i2">Pull the latest branch with display.py / display_loop.py / display.service.<pre><code>cd /usr/lib/cgi-bin/remote-switch
+sudo -u leith git pull</code></pre>(Match the deploy convention — never <code>sudo git pull</code>, it changes file ownership.)</label></div>
+</div>
+
+<h2>Dry-run sanity check (no SPI write)</h2>
+<p>Before driving the panel, confirm state-read + render work standalone.</p>
+<div class="step">
+  <input type="checkbox" id="dr1">
+  <div class="step-body"><label for="dr1">Render once to PNG, no SPI.<pre><code>cd /usr/lib/cgi-bin/remote-switch
+DISPLAY_DRY_RUN=1 python3 display_loop.py --once
+ls -la /tmp/display-current.png</code></pre>Output should print <code>wrote /tmp/display-current.png</code> and the file should be ~5–10 KB.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="dr2">
+  <div class="step-body"><label for="dr2">scp the PNG back to your laptop and eyeball it.<pre><code>scp pi.vpn:/tmp/display-current.png .
+open display-current.png</code></pre>Should show: heater state, schedule (if any), FlashAir status, HVAC + hangar temp footer.</label></div>
+</div>
+
+<h2>First light — drive the panel</h2>
+<div class="step">
+  <input type="checkbox" id="fl1">
+  <div class="step-body"><label for="fl1">Render one frame to the actual display.<pre><code>cd /usr/lib/cgi-bin/remote-switch
+sudo python3 display_loop.py --once</code></pre>The display should light up and show the same frame the dry-run PNG produced.</label></div>
+</div>
+<div class="note">
+  <strong>If the display stays blank:</strong> check power continuity (multimeter across VCC/GND should read 3.3V), check that <code>raspi-gpio get 8 24 25</code> shows OUTPUT on those pins after running the script, check the journal for SPI errors with <code>dmesg | tail -20</code>.
+</div>
+<div class="note">
+  <strong>If text is sideways or mirrored:</strong> the <code>rotate=</code> argument in <code>display_loop.py</code> needs adjusting. Try <code>rotate=0</code>, <code>2</code>, or <code>3</code> until orientation matches the mockup.
+</div>
+<div class="note">
+  <strong>If colors are swapped (red↔blue):</strong> the panel is using BGR ordering instead of RGB. <code>luma.lcd</code> can be told via <code>bgr=True</code> on the <code>ili9341()</code> constructor — add that and re-test.
+</div>
+
+<h2>Enable the service</h2>
+<div class="step">
+  <input type="checkbox" id="sv1">
+  <div class="step-body"><label for="sv1">Install the systemd unit.<pre><code>sudo cp /usr/lib/cgi-bin/remote-switch/display.service /etc/systemd/system/
+sudo systemctl daemon-reload</code></pre></label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="sv2">
+  <div class="step-body"><label for="sv2">Start it and watch for clean startup.<pre><code>sudo systemctl start display
+sudo systemctl status display</code></pre>Status should show <code>active (running)</code> with no errors.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="sv3">
+  <div class="step-body"><label for="sv3">Enable on boot.<pre><code>sudo systemctl enable display</code></pre></label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="sv4">
+  <div class="step-body"><label for="sv4">Tail the journal for 30s — confirm no errors, no restarts.<pre><code>sudo journalctl -fu display</code></pre>Should be mostly silent — errors print to stderr only on transient hiccups.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="sv5">
+  <div class="step-body"><label for="sv5">Display refreshes every 5 seconds — schedule countdown ticks down, "updated Xs ago" stays low single digits.</label></div>
+</div>
+
+<h2>Configure the FlashAir SSID pattern (optional)</h2>
+<p>The renderer colors a matching SSID as amber ("active") and others as grey ("steady state"). Default pattern is <code>flashair</code>. Override in <code>.env</code>:</p>
+<pre><code>echo 'FLASHAIR_SSID_PATTERN=flashair' | sudo tee -a /usr/lib/cgi-bin/remote-switch/.env</code></pre>
+<div class="step">
+  <input type="checkbox" id="cfg1">
+  <div class="step-body"><label for="cfg1">Confirmed the FlashAir card's SSID broadcasts a substring matching the pattern (default <code>flashair</code> works for stock FlashAir cards).</label></div>
+</div>
+
+<h2>Final checks</h2>
+<div class="step">
+  <input type="checkbox" id="f1">
+  <div class="step-body"><label for="f1">Reboot the Pi — <code>sudo reboot</code> — and confirm the display comes up cleanly within ~30s of boot.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="f2">
+  <div class="step-body"><label for="f2">Toggle the heater from the web UI — display reflects the change within 5 seconds.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="f3">
+  <div class="step-body"><label for="f3">Add a heater schedule from the web UI — "Schedule" section on the display shows the next event.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="f4">
+  <div class="step-body"><label for="f4">FlashAir status surfaces once flashair-sync's status writer is deployed (depends on phase 1 PRs being merged).</label></div>
+</div>
+
+<h2>Troubleshooting cheat-sheet</h2>
+<table>
+  <thead><tr><th>Symptom</th><th>Likely cause</th><th>Fix</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>Display blank, service running</td>
+      <td>SPI not loaded, or wiring</td>
+      <td><code>ls /dev/spidev*</code> + check pin map</td>
+    </tr>
+    <tr>
+      <td>Service crash-looping</td>
+      <td>luma.lcd missing, or SPI permission</td>
+      <td><code>journalctl -u display -n 50</code></td>
+    </tr>
+    <tr>
+      <td>Display dim / flickering</td>
+      <td>Power supply marginal, long jumpers</td>
+      <td>Shorter jumpers, beefier PSU</td>
+    </tr>
+    <tr>
+      <td>Text shifted / cropped</td>
+      <td>Wrong rotation value</td>
+      <td>Try <code>rotate=0/1/2/3</code> in display_loop.py</td>
+    </tr>
+    <tr>
+      <td>Red ↔ blue swap</td>
+      <td>Panel is BGR, code expects RGB</td>
+      <td>Add <code>bgr=True</code> to <code>ili9341()</code></td>
+    </tr>
+    <tr>
+      <td>"updated Xm ago" stuck</td>
+      <td>flashair-sync stopped writing the cache</td>
+      <td><code>systemctl status flashair-sync</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Files in this repo</h2>
+<ul>
+  <li><code>display.py</code> — pure renderer; <code>render(state) → PIL.Image</code></li>
+  <li><code>display_state.py</code> — assembles state from /run/ + DB + GPIO + HVAC cache</li>
+  <li><code>display_loop.py</code> — systemd entry point, 5s loop, dry-run support</li>
+  <li><code>display.service</code> — systemd unit, <code>User=root</code> (needs SPI + GPIO access)</li>
+  <li><code>docs/display-install.html</code> — this file</li>
+</ul>
+
+<div class="reset">
+  <button id="reset-btn">Reset progress</button>
+</div>
+
+<script>
+(function() {
+  const KEY = 'hangar-display-install-progress';
+  const boxes = document.querySelectorAll('input[type=checkbox]');
+  const text = document.getElementById('progress-text');
+  const fill = document.getElementById('progress-fill');
+  const reset = document.getElementById('reset-btn');
+
+  // Restore
+  try {
+    const saved = JSON.parse(localStorage.getItem(KEY) || '{}');
+    boxes.forEach(b => {
+      if (saved[b.id]) {
+        b.checked = true;
+        b.closest('.step').classList.add('done');
+      }
+    });
+  } catch (e) {}
+
+  function update() {
+    const state = {};
+    let done = 0;
+    boxes.forEach(b => {
+      state[b.id] = b.checked;
+      if (b.checked) done++;
+      b.closest('.step').classList.toggle('done', b.checked);
+    });
+    try { localStorage.setItem(KEY, JSON.stringify(state)); } catch (e) {}
+    text.textContent = `${done} of ${boxes.length} steps done`;
+    fill.style.width = `${(done / boxes.length) * 100}%`;
+  }
+
+  boxes.forEach(b => b.addEventListener('change', update));
+  reset.addEventListener('click', () => {
+    if (confirm('Reset all checkboxes?')) {
+      try { localStorage.removeItem(KEY); } catch (e) {}
+      boxes.forEach(b => { b.checked = false; });
+      update();
+    }
+  });
+  update();
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds an at-a-glance OLED dashboard on the hangar Pi — engine heater state, FlashAir sync progress, HVAC mode, hangar temp. Designed to answer **"are the CSVs off the card, safe to power down?"** post-flight without unlocking a phone.

**Hardware:** 3.2" ILI9341 SPI TFT (DIANN/Pasotim MSP3218 or equivalent, ~\$18). Wired to the Pi Zero W's existing GPIO header — no new infra. All pins (BCM 8/10/11/24/25) verified free via `raspi-gpio` against the existing heater (BCM 17), fan (BCM 27), and 1-Wire probe (BCM 4). Touch is wired but its handler is intentionally deferred to a follow-up — XPT2046 calibration needs hardware in hand.

Pairs with [#33](https://github.com/leithl/remote-switch/pull/33) (already merged) — `display_state.py` reads `/run/heater-flashair.json` through `flashair.read_cache()` so both views stay in lock-step on the file path + staleness threshold.

## What's added

| File | Purpose |
|---|---|
| `display.py` | Pure renderer. `render(state) → PIL.Image`. Module-level `HEATER_BUTTON_RECT` exposed for the (future) touch handler. Lazy PIL import (matches `hvac.py`'s msmart pattern). |
| `display_state.py` | Assembles state from `/run/heater.db`, `/run/heater-hvac.json`, `/run/heater-flashair.json`, the disk `schedules` table, and GPIO 17. Each source independent — missing data degrades gracefully. |
| `display_loop.py` | systemd entry point. 5s loop, `--once` mode for spot checks, `--dry-run` mode that skips SPI and writes `/tmp/display-current.png` each iteration. SIGTERM responsive within 100ms (chunked sleep). |
| `display.service` | systemd unit, `User=root` for SPI + GPIO access, `Restart=always`. |
| `docs/display-install.html` | Wiring + install checklist with persistent (localStorage) checkboxes, pin map, troubleshooting table. Print-friendly. |

## Layout

- **Top half** — ENGINE HEATER label + big touchable button (140×70 px) + next-event preview
- **Middle** — FLASHAIR with stage-aware text, SSID indicator (when v1 contract lands), \"updated Xs ago\" freshness, progress bar during transfers
- **Footer** — HVAC mode/target/power + hangar temp, muted (redundant with the wall unit + remote)

## Reads / writes

- **Reads only.** Never writes to `/run/heater-hvac.json` (the display path must NOT trigger dongle round-trips — log_temp.py stays canonical) and never writes `/run/heater-flashair.json` (that's flashair-sync's file).
- Handles **both FlashAir contract generations** — v0 (current main, `transferring` boolean) and v1 (follow-up PR with `stage` enum + `current_ssid` + `files_done/total`). On v0 the SSID indicator is suppressed (no key) so the renderer doesn't show a misleading \"no wifi\" red.

## Test plan

- [x] Empty-state render (macOS, no /run/ files) — heater OFF, no schedule, \"not configured\" for FlashAir, HVAC/temp lines omitted. No crashes.
- [x] v0 FlashAir contract → state dict + render correct (downloading shows progress; idle shows \"done — N files, X ago\" with green when recent).
- [x] v1 contract forward-compat verified end-to-end with a mock JSON.
- [x] Dry-run mode writes PNG without SPI init.
- [ ] **First-light on real ILI9341 SPI panel** — user follows `docs/display-install.html` once hardware arrives.
- [ ] **systemd service starts cleanly on boot** — `systemctl status display` shows `active (running)`.
- [ ] **Touch handler** — separate follow-up after first-light + XPT2046 calibration.

## Constraints honored

- No new daemons or hot-path infra beyond the 5s display loop.
- No new packages on the deploy host until first-light (`luma.lcd` install is in the checklist).
- Per-iteration `try/except` so DB locks during the weekly flush don't kill the process.
- SPI is currently OFF in `/boot/firmware/config.txt` — install checklist enables it (`raspi-config nonint do_spi 0`).
- mod_wsgi reload semantics: changes are to new files only; `switch.py` is untouched, so no `touch switch.py` needed at deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)