### PR TITLE
display: tighten refresh while seconds visible + on tap

### DIFF
--- a/display.py
+++ b/display.py
@@ -143,6 +143,22 @@ def fmt_age(secs):
     return f"{secs // 86400}d"
 
 
+def has_seconds_resolution(state):
+    """True if any field in this state would render fmt_age() in the seconds
+    branch (< 60s). The display loop uses this to tighten the refresh interval
+    so the visible 'Xs ago' counter ticks every second instead of jumping in
+    5-second steps. Only the FlashAir block has seconds-resolution callers."""
+    fa = state.get("flashair")
+    if fa is None:
+        return False
+    now = state.get("now_epoch", 0)
+    for key in ("epoch", "last_sync_epoch"):
+        t = fa.get(key)
+        if t is not None and 0 <= now - t < 60:
+            return True
+    return False
+
+
 def fmt_until(secs):
     if secs is None or secs < 0:
         return ""

--- a/display_loop.py
+++ b/display_loop.py
@@ -33,8 +33,9 @@ import display          # noqa: E402
 import display_state    # noqa: E402
 
 
-UPDATE_INTERVAL_SECS     = 5
-TOUCH_POLL_INTERVAL_SECS = 0.05    # 20 Hz touch polling between display refreshes
+UPDATE_INTERVAL_SECS      = 5
+UPDATE_INTERVAL_FAST_SECS = 1      # used while a 'Xs ago' counter is on screen
+TOUCH_POLL_INTERVAL_SECS  = 0.05   # 20 Hz touch polling between display refreshes
 TOUCH_DEBOUNCE_SECS      = 1.0     # ignore taps within this window of the last one
 DRY_RUN_OUT              = Path("/tmp/display-current.png")
 
@@ -46,6 +47,7 @@ SPI_DEV  = 0   # SPI0 CE0 — the display's chip select (BCM 8)
 
 
 _stop = False
+_redraw_now = False    # set by _poll_touch when an action fires; consumed by _sleep_with_touch
 _last_tap_epoch = 0.0
 
 
@@ -93,28 +95,34 @@ def _flashair_ssid_pattern():
 
 
 def _push(device, ssid_pattern):
-    """Render one frame and push it. Returns True iff the push succeeded.
-    Errors logged, never raised."""
+    """Render one frame and push it. Returns (ok, next_interval_secs).
+    Errors logged, never raised; failure paths fall back to the slow interval."""
     try:
         state = display_state.get_state()
         img = display.render(state, flashair_ssid_pattern=ssid_pattern)
     except Exception as e:
         sys.stderr.write(f"display: state/render failed: {e}\n")
-        return False
+        return False, UPDATE_INTERVAL_SECS
+
+    next_interval = (
+        UPDATE_INTERVAL_FAST_SECS
+        if display.has_seconds_resolution(state)
+        else UPDATE_INTERVAL_SECS
+    )
 
     try:
         if device is None:
             img.save(DRY_RUN_OUT)
         else:
             device.display(img)
-        return True
+        return True, next_interval
     except Exception as e:
         # Transient SPI hiccups shouldn't kill the loop — systemd Restart handles real crashes.
         # Include exception class name so silently-stringified errors are diagnosable.
         sys.stderr.write(
             f"display: push failed: {type(e).__name__}: {e!r}\n"
         )
-        return False
+        return False, UPDATE_INTERVAL_SECS
 
 
 def _toggle_heater():
@@ -151,20 +159,26 @@ def _poll_touch(touch_reader):
     x_px, y_px = touch_reader.to_pixels(*avg)
     import touch  # local module; cheap re-import is cached
     if touch.point_in_rect(x_px, y_px, display.HEATER_BUTTON_RECT):
+        global _redraw_now
         _last_tap_epoch = now
         _toggle_heater()
+        _redraw_now = True   # wake _sleep_with_touch so the button color flips immediately
 
 
 def _sleep_with_touch(secs, touch_reader):
     """Sleep for `secs` total, polling touch every TOUCH_POLL_INTERVAL_SECS
-    and breaking early on SIGTERM. Replaces the previous plain time.sleep
-    chunks in the main loop."""
+    and breaking early on SIGTERM or when a tap requests an immediate redraw.
+    Replaces the previous plain time.sleep chunks in the main loop."""
+    global _redraw_now
     chunks = int(secs / TOUCH_POLL_INTERVAL_SECS)
     for _ in range(chunks):
         if _stop:
             return
         if touch_reader is not None:
             _poll_touch(touch_reader)
+        if _redraw_now:
+            _redraw_now = False
+            return
         time.sleep(TOUCH_POLL_INTERVAL_SECS)
 
 
@@ -191,7 +205,7 @@ def main():
     ssid_pattern = _flashair_ssid_pattern()
 
     if "--once" in sys.argv:
-        ok = _push(device, ssid_pattern)
+        ok, _ = _push(device, ssid_pattern)
         if _is_dry_run() and ok:
             print(f"wrote {DRY_RUN_OUT}")
         # Normal interpreter exit triggers luma.lcd's cleanup, which clears
@@ -202,8 +216,8 @@ def main():
 
     try:
         while not _stop:
-            _push(device, ssid_pattern)
-            _sleep_with_touch(UPDATE_INTERVAL_SECS, touch_reader)
+            _, interval = _push(device, ssid_pattern)
+            _sleep_with_touch(interval, touch_reader)
     finally:
         if touch_reader is not None:
             touch_reader.close()


### PR DESCRIPTION
## Summary

Two changes to the display_loop's refresh cadence, both addressing the same visible-latency annoyance — the fixed 5s tick was the bottleneck.

- **Adaptive cadence.** The FlashAir header's "updated Xs ago" (and the "done/idle — Xs ago" status line) used to jump 5 at a time because the loop ran every 5s. Now: when any rendered field is in `fmt_age`'s seconds branch (<60s), the loop drops to 1s so the digit ticks naturally; it returns to 5s as soon as the value crosses into minutes (where the cadence is invisible anyway). New helper `display.has_seconds_resolution(state)` inspects the FlashAir block (`epoch` / `last_sync_epoch`) — the only place `fmt_age` renders below 60s. `_push` picks fast vs slow and returns the interval.
- **Immediate redraw on tap.** Touch already polled at 20 Hz, so GPIO 17 flipped within ~50 ms of a tap — but the visible button color swap waited for the next `_push`, up to 5s late. `_poll_touch` now sets a `_redraw_now` flag after a rect-hit heater toggle, and `_sleep_with_touch` breaks early on its next 50 ms chunk. On-screen flip now lands within ~50 ms plus one render+push.

## Cost

Fast cadence only kicks in for up to ~60s after a FlashAir sync state change. Outside that window, behaviour is identical to before. Everything stays in tmpfs — no SD writes added.

## Test plan

- [ ] After deploy, watch the FlashAir header right after a sync: "Xs ago" should count up 1-by-1 (1s, 2s, 3s…), then drop back to 5s cadence once it crosses to "1m".
- [ ] Tap the heater button: visible ON↔OFF flip should feel instant (well under 1s), not delayed up to 5s.
- [ ] `--once` still works as before (the unpacked return value path).
- [ ] `--dry-run` still writes `/tmp/display-current.png`.
- [ ] Tap outside `HEATER_BUTTON_RECT` should NOT wake the loop (flag is only set inside the rect-hit branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)