### PR TITLE
fix(chart): repair ambient tooltip + don't fabricate ambient line across API outages

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ import glob
 import json
 import os
 import sqlite3
+import sys
 import urllib.request
 from datetime import datetime
 from io import StringIO
@@ -229,7 +230,11 @@ def fetch_ambient(lat, lon):
         temp = data["current"]["temperature_2m"]
         AMBIENT_CACHE.write_text(f"{now},{temp}\n")
         return float(temp)
-    except Exception:
+    except Exception as e:
+        # Cron captures stderr; route to journal so multi-hour outages
+        # (which silently leave ambient_c=NULL across many rows) are
+        # diagnosable after the fact instead of invisible.
+        print(f"fetch_ambient failed: {type(e).__name__}: {e}", file=sys.stderr)
         return None
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -312,11 +312,18 @@ var fanData = buildRangeData(data, fanRanges);
 // x-values with null in the gaps. Chart.js tooltip.mode='index' looks items
 // up by array index across datasets, so a sparse dataset misses tooltips
 // at the very x positions where it does have a point. Heater/fan get the
-// same treatment via buildRangeData above.
+// same treatment via buildRangeData above. ambientData gets it too: when
+// the upstream weather API fails, ambient_c is null for those buckets and
+// aggregate.py skips them, leaving fewer ambient points than temp points.
 var powerByX = {};
 powerData.forEach(function(p) { powerByX[p.x] = p.y; });
 var powerDataAligned = data.map(function(d) {
   return { x: d.x, y: powerByX[d.x] !== undefined ? powerByX[d.x] : null };
+});
+var ambientByX = {};
+ambientData.forEach(function(p) { ambientByX[p.x] = p.y; });
+var ambientDataAligned = data.map(function(d) {
+  return { x: d.x, y: ambientByX[d.x] !== undefined ? ambientByX[d.x] : null };
 });
 // Inline cold-band plugin: replaces chartjs-plugin-annotation (~12 KB) for
 // the single use case of drawing orange boxes over cold-temp ranges.
@@ -395,7 +402,10 @@ if (data.length > 0) {
         tension: 0.3,
         spanGaps: false
       }, {
-        data: ambientData,
+        // Ambient is sparse when the upstream weather API fails — align
+        // it to the temp x-array (nulls where ambient is missing) so the
+        // tooltip's mode='index' lookup finds the matching point.
+        data: ambientDataAligned,
         borderColor: 'rgb(34, 197, 94)',
         backgroundColor: 'transparent',
         fill: false,

--- a/templates/index.html
+++ b/templates/index.html
@@ -404,7 +404,10 @@ if (data.length > 0) {
       }, {
         // Ambient is sparse when the upstream weather API fails — align
         // it to the temp x-array (nulls where ambient is missing) so the
-        // tooltip's mode='index' lookup finds the matching point.
+        // tooltip's mode='index' lookup finds the matching point. spanGaps
+        // is bounded at 10 min so short hiccups still smooth visually, but
+        // multi-hour outages render as line breaks rather than a fabricated
+        // monotone curve across the gap.
         data: ambientDataAligned,
         borderColor: 'rgb(34, 197, 94)',
         backgroundColor: 'transparent',
@@ -412,7 +415,7 @@ if (data.length > 0) {
         pointRadius: 0,
         tension: 0.4,
         cubicInterpolationMode: 'monotone',
-        spanGaps: true
+        spanGaps: 600000
       }, {
         // HVAC compressor power draw — bound to the right Watts axis (y1).
         // Only buckets above the standby threshold (>100W) are present;


### PR DESCRIPTION
## Symptom (from today, 2026-05-26)

The Open-Meteo `current=temperature_2m` API silently failed for **156 minutes (06:20–08:55 MST)**, leaving `ambient_c=NULL` across that window. Two distinct user-visible bugs surfaced from that single root cause:

1. **Tooltip dropped the ambient label** at arbitrary cursor positions on the 1-day view (only `Hangar: 76.6°F` was shown — no ambient line in the tooltip even when the green line was visible).
2. **The ambient line looked "smooth-stepped"** through the gap: a monotone curve from `52.5°F at 05:49` to `62.1°F at 08:56` was drawn across 2.5 hours where no data actually existed. Looked plausible but was fabricated.

## Why

- `aggregate.compute_bucketed` only appends to `ambient_data` when `avg_ambient_c is not None`. With 156 missing minutes, the array had 344 points vs `chart_data`'s 500. Chart.js `tooltip.mode='index'` resolves by array position, so the cursor's effective ambient index pointed off the end of the array.
- The ambient dataset had `spanGaps: true` + `cubicInterpolationMode: 'monotone'`, so any gap (no matter how long) got interpolated through.
- `config.fetch_ambient` swallowed every exception with a bare `except Exception: return None` and no logging — so we have no idea whether the 156-min outage was a timeout, DNS failure, HTTP 5xx, or malformed JSON.

## Summary

- **`templates/index.html`** — build `ambientDataAligned` by mapping over the temp data's x-array, mirroring the existing `powerDataAligned` pattern. Tooltip now finds the matching ambient point at every cursor position.
- **`templates/index.html`** — change `spanGaps: true` → `spanGaps: 600000` (10 min in ms) on the ambient dataset. Short API hiccups still smooth; multi-hour outages render as breaks.
- **`config.py`** — log fetch_ambient exception class + message to stderr. Cron routes stderr to the journal, so future outages are diagnosable instead of invisible.

## Test plan
- [ ] Pull and `touch switch.py` on the Pi (no module file changed other than `config.py`, but the template is loaded fresh per-request so that doesn't strictly need a reload — the `config.py` change is picked up by cron's next minute run)
- [ ] Verify the 1-day chart tooltip now shows both `Hangar:` and `Ambient:` at every cursor position, including over today's 06:20–08:55 gap (which should now render as a visible break in the green line, not a smooth curve)
- [ ] Trigger an artificial fetch_ambient failure (e.g., briefly block api.open-meteo.com in ufw) and confirm `journalctl -u cron --since "5 min ago" | grep fetch_ambient` shows the exception class/message

🤖 Generated with [Claude Code](https://claude.com/claude-code)