### PR TITLE
fix(chart): clear ambient rolling avg on null buckets — no phantom recovery ramp

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -332,10 +332,16 @@ def compute_bucketed(rows, cutoff, chart_end, bucket_secs=900):
         if avg_ac_power_w is not None and avg_ac_power_w > POWER_ON_THRESHOLD_W:
             power_data.append({"x": b * 1000, "y": round(avg_ac_power_w, 1)})
 
-        # Ambient (4-bucket rolling avg)
+        # Ambient (4-bucket rolling avg). Clear the window on a null bucket
+        # so a multi-hour API gap doesn't leak its pre-gap values into the
+        # first few post-gap rolling averages — otherwise the chart shows a
+        # phantom 3-minute ramp from the pre-gap temp to the post-gap temp
+        # that didn't actually happen in the weather data.
         if avg_ambient_c is not None:
             amb_window.append(avg_ambient_c * 1.8 + 32)
             ambient_data.append({"x": b * 1000, "y": round(sum(amb_window) / len(amb_window), 1)})
+        else:
+            amb_window.clear()
 
     # Close open ranges
     if in_heater:


### PR DESCRIPTION
## Symptom (visible on the live chart after PR #37 deployed)

With the gap now correctly rendered as a break, a new artifact became obvious: the ambient line resumes at ~52°F at 08:56 and ramps to ~62°F over the next 3 minutes — but the raw data jumps cleanly from NULL straight to 62.1°F at 08:56. The ramp was fabricated.

## Why

\`aggregate.compute_bucketed\` maintains a 4-bucket rolling average for ambient, but only updates the window when \`avg_ambient_c is not None\`. Across the 2.5-hour gap, the deque held the last 4 pre-gap values (all ~52.5°F). When the first post-gap reading (62.1°F) arrived:

- 08:56: window = [52.5, 52.5, 52.5, 62.1] → avg = 54.9°F
- 08:57: window = [52.5, 52.5, 62.1, 62.1] → avg = 57.3°F
- 08:58: window = [52.5, 62.1, 62.1, 62.1] → avg = 59.7°F
- 08:59: window = [62.1, 62.1, 62.1, 62.1] → avg = 62.1°F

Three minutes of pre-gap data leaking into post-gap averages.

## Fix

One-line: clear the deque on null buckets. Post-gap series now starts fresh.

\`compute()\` (used only by the monthly rollup) has the same shape of bug but isn't worth fixing — at 15-min bucket resolution the artifact is ~60 min wide, which is barely a pixel at month scale.

## Test plan
- [ ] After deploy, reload the 1-day chart and confirm the ambient line restarts at 62.1°F at 08:56 with no ramp
- [ ] Tooltip at 08:56 should show \`Ambient: 62.1°F\` (no smoothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)