### PR TITLE
fix(display): unclip "done" headline at 320px + pluralize active-stage context

### DIFF
--- a/display.py
+++ b/display.py
@@ -225,19 +225,23 @@ def flashair_lines(fa):
     if stage == "scanning":
         return ("scanning card", COLOR["flash_active"], None, None, False)
     if stage == "downloading_logs":
-        ctx = f"{session_shots_n} shots queued" if session_shots_n else None
+        shot_word = "shot" if session_shots_n == 1 else "shots"
+        ctx = f"{session_shots_n} {shot_word} queued" if session_shots_n else None
         return (f"downloading  {fd} of {ft} logs",
                 COLOR["flash_active"], cf, ctx, True)
     if stage == "downloading_shots":
-        ctx = f"{session_csv_n} logs done" if session_csv_n else None
+        log_word = "log" if session_csv_n == 1 else "logs"
+        ctx = f"{session_csv_n} {log_word} done" if session_csv_n else None
         return (f"downloading  {fd} of {ft} shots",
                 COLOR["flash_active"], cf, ctx, True)
     if stage == "uploading_logs":
-        ctx = f"{session_shots_n} shots queued" if session_shots_n else None
+        shot_word = "shot" if session_shots_n == 1 else "shots"
+        ctx = f"{session_shots_n} {shot_word} queued" if session_shots_n else None
         return (f"uploading  {fd} of {ft} logs",
                 COLOR["flash_active"], cf, ctx, True)
     if stage == "uploading_shots":
-        ctx = f"{session_csv_n} logs done" if session_csv_n else None
+        log_word = "log" if session_csv_n == 1 else "logs"
+        ctx = f"{session_csv_n} {log_word} done" if session_csv_n else None
         return (f"uploading  {fd} of {ft} shots",
                 COLOR["flash_active"], cf, ctx, True)
     # Back-compat: pre-stage v0 contract inferred "downloading" from the

--- a/display.py
+++ b/display.py
@@ -214,14 +214,15 @@ def flashair_lines(fa):
             done_text = f"{n} {log_unit} + {shot_n} {shot_unit}"
         else:
             done_text = f"{n} {log_unit}"
+        # Age goes on the sub line — the headline ran past 320px once the
+        # breakdown carried both logs and shots ("done — 6 logs + 1 shot,
+        # 28s ago" clipped the trailing "o").
+        ago = f"{fmt_age(age_since_sync)} ago" if age_since_sync is not None else None
         if age_since_sync is not None and age_since_sync < DONE_WINDOW_SECS:
-            return (f"done — {done_text}, {fmt_age(age_since_sync)} ago",
-                    COLOR["flash_done"], None, None, False)
-        # Mirror the "done —" structure; "last sync" pushed the line past
-        # 320px when both logs and shots had counts in the breakdown.
-        ago = fmt_age(age_since_sync) if age_since_sync is not None else "—"
-        return (f"idle — {done_text}, {ago} ago",
-                COLOR["flash_idle"], None, None, False)
+            return (f"done — {done_text}",
+                    COLOR["flash_done"], ago, None, False)
+        return (f"idle — {done_text}",
+                COLOR["flash_idle"], ago, None, False)
     if stage == "scanning":
         return ("scanning card", COLOR["flash_active"], None, None, False)
     if stage == "downloading_logs":


### PR DESCRIPTION
## Summary

Two small bugs surfaced in [a video of a sync cycle](https://github.com/leithl/remote-switch/pull/38) yesterday. Both in `flashair_lines()`, both in the FlashAir block of the touchscreen display, two commits in this PR.

### 1. "done" headline clips at the right edge

The post-sync state showed:

> `done — 6 logs + 1 shot, 28s ag`  ← trailing "o" of "ago" clipped

The headline ran past 320px once the breakdown included both logs and shots. Worst case `idle — 99 logs + 99 shots, 12h05m ago` was never going to fit either.

Split: the bold green/orange headline now carries just `done — N logs + M shots`; the dim mono sub line below shows `X ago`. The two rows were already different visual weights, this just uses the existing two-row layout that active stages already use.

Mockup (`done` state):

```
FLASHAIR  on "Hangar-WiFi"          updated 4s ago
done — 7 logs + 5 shots
1m ago
```

### 2. "1 shots queued" — pluralization

The four active-stage branches (`downloading_logs`, `downloading_shots`, `uploading_logs`, `uploading_shots`) hard-coded the plural form. The `idle`/`done` branch already pluralized; this brings them in line.

> `1 shots queued`  →  `1 shot queued`
> `1 logs done`     →  `1 log done`
> `5 shots queued`  unchanged

## Verification

Mockup PNGs regenerate clean (`python3 display.py`):

```
done headline: 'done — 6 logs + 1 shot'  sub: '28s ago'
downloading w/ 1 shot queued: ctx='1 shot queued'
uploading_shots w/ 1 log done: ctx='1 log done'
downloading w/ 5 shots queued: ctx='5 shots queued'  (unchanged)
```

## Test plan

- [ ] `git pull` on the Pi (touches `display.py` → display_loop.py picks it up on next render tick)
- [ ] Glance at the touchscreen — `done` line should fit cleanly with age on a separate small line beneath
- [ ] On next sync that has a singular shot: confirm "1 shot queued" reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)