### PR TITLE
feat(display): render on FlashAir status file change, not just on the 1s/5s tick

### DIFF
--- a/display_loop.py
+++ b/display_loop.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import config           # noqa: E402  (path-modifying import above)
 import display          # noqa: E402
 import display_state    # noqa: E402
+import flashair         # noqa: E402
 
 
 UPDATE_INTERVAL_SECS      = 5
@@ -165,10 +166,21 @@ def _poll_touch(touch_reader):
         _redraw_now = True   # wake _sleep_with_touch so the button color flips immediately
 
 
-def _sleep_with_touch(secs, touch_reader):
+def _flashair_mtime_ns():
+    """Returns the FlashAir status file's mtime in ns, or 0 if absent / unreadable.
+    Used to wake the render loop within ~50 ms of any daemon status write, instead
+    of waiting out the fixed 1s/5s cadence. The daemon writes via atomic temp+rename
+    (flashair_sync._write_status), so every transition bumps mtime cleanly."""
+    try:
+        return flashair.FLASHAIR_STATUS_FILE.stat().st_mtime_ns
+    except OSError:
+        return 0
+
+
+def _sleep_with_touch(secs, touch_reader, fa_mtime_baseline):
     """Sleep for `secs` total, polling touch every TOUCH_POLL_INTERVAL_SECS
-    and breaking early on SIGTERM or when a tap requests an immediate redraw.
-    Replaces the previous plain time.sleep chunks in the main loop."""
+    and breaking early on SIGTERM, on a tap requesting an immediate redraw,
+    or when the FlashAir status file changes (daemon wrote new state)."""
     global _redraw_now
     chunks = int(secs / TOUCH_POLL_INTERVAL_SECS)
     for _ in range(chunks):
@@ -178,6 +190,8 @@ def _sleep_with_touch(secs, touch_reader):
             _poll_touch(touch_reader)
         if _redraw_now:
             _redraw_now = False
+            return
+        if _flashair_mtime_ns() != fa_mtime_baseline:
             return
         time.sleep(TOUCH_POLL_INTERVAL_SECS)
 
@@ -217,7 +231,11 @@ def main():
     try:
         while not _stop:
             _, interval = _push(device, ssid_pattern)
-            _sleep_with_touch(interval, touch_reader)
+            # Capture mtime after rendering — the frame on screen reflects whatever
+            # was in the file at that moment, so a later mtime means there's new
+            # state to render.
+            fa_mtime = _flashair_mtime_ns()
+            _sleep_with_touch(interval, touch_reader, fa_mtime)
     finally:
         if touch_reader is not None:
             touch_reader.close()


### PR DESCRIPTION
## Summary

PR #36 dropped the render cadence to 1s during active sync phases, but two file completions inside the same 1s window still collapse on screen — yesterday's video showed `uploading 2 of 5 logs` jumping directly to `uploading 4 of 5 logs` because file 3's "in flight" and "done" both landed inside one render interval.

This PR makes the display render **on every daemon status-file write**, not just on the timer. The 1s/5s cadence becomes an upper bound, not a fixed pulse.

## Mechanism

The touch-polling sleep loop in [display_loop.py](display_loop.py) already iterates at 50 ms. One extra `stat()` per iteration is essentially free on a Pi Zero. Compare the file's `st_mtime_ns` against a baseline captured after the previous render — if it moved, break out of sleep and re-render.

The daemon writes via atomic temp+rename ([flashair_sync._write_status](https://github.com/leithl/flashair-sync/blob/main/flashair_sync.py#L362)), so mtime bumps cleanly on every transition (stage change, files_done bump, SSID change, etc.).

## Why mtime polling and not inotify

`inotify_simple` / `pyinotify` would be a new dep + an async fd to thread through the loop. mtime polling fits the existing 50 ms touch-poll pattern with zero new dependencies. CPU cost is negligible (~one syscall per 50 ms; Pi Zero handles this in microseconds).

## Why PR #36's adaptive interval is still needed

The interval still controls how often we redraw when **nothing in the file changes** — e.g., during idle, the "X ago" counter on screen needs to advance from `5s` to `6s` even though the file hasn't been written. Without the 1s adaptive interval, idle "Xs ago" would freeze between daemon heartbeats.

So both pieces stay:
- **Interval** (1s/5s adaptive) = "tick on-screen timers"
- **mtime watch** = "react to new state"

## Test plan

- [ ] After deploy, watch the touchscreen during a FlashAir sync — count progression `1 of 5 → 2 of 5 → 3 of 5 → …` should be visible end-to-end, no skips.
- [ ] `--dry-run --once` and `--once` paths unchanged (don't enter `_sleep_with_touch`).
- [ ] Tap-to-toggle still flips heater color in <1s (existing `_redraw_now` path).
- [ ] When `/run/flashair-shots/heater-flashair.json` is absent (flashair-sync stopped), no crashes — `_flashair_mtime_ns()` returns 0 and the loop falls back to the timer-only cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)