### PR TITLE
feat(display): heater button colors → punchy red + deep emerald green

### DIFF
--- a/display.py
+++ b/display.py
@@ -69,9 +69,9 @@ COLOR = {
     "dim":             (110, 115, 125),
     "very_dim":        (175, 180, 190),
     "rule":            (215, 220, 230),
-    "heater_on_bg":    (218, 50, 60),    # vibrant red — heater is ON
+    "heater_on_bg":    (235, 40, 45),    # punchy saturated red — heater is ON
     "heater_on_fg":    (255, 255, 255),
-    "heater_off_bg":   (38, 175, 85),    # vibrant green — heater is OFF (safe)
+    "heater_off_bg":   (25, 155, 70),    # deep emerald green — heater is OFF (safe)
     "heater_off_fg":   (255, 255, 255),
     "heater_border":   (160, 165, 175),
     "sched":           (50, 55, 65),


### PR DESCRIPTION
Color picks after side-by-side preview comparison: red B (235, 40, 45) + green D (25, 155, 70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)