### PR TITLE
feat(display): honest FlashAir status — checking stage + connecting/connected SSID

### DIFF
--- a/display.py
+++ b/display.py
@@ -281,6 +281,37 @@ def ssid_color(ssid, flashair_pattern=None):
     return COLOR["ssid_hangar"]
 
 
+# Stages where the daemon is working the FlashAir card directly. During these
+# the WiFi indicator reads "connected flashair" regardless of a transient None
+# SSID (a re-association blip), rather than flashing a misleading "no wifi".
+_ON_CARD_STAGES = {"checking_logs", "downloading_logs", "downloading_shots"}
+
+
+def _ssid_indicator(ssid, stage, flashair_pattern=None):
+    """Return (label, color) for the WiFi line in the FlashAir header.
+
+    The raw card SSID is noise — the user already configured it — and the bare
+    None the radio reports mid-association rendered as an alarming "no wifi".
+    So collapse the card's networks to plain status text:
+
+    - on the card (SSID matches the pattern, or mid-transfer from it)
+        → "connected flashair"
+    - hopping onto the card (scanning with the radio between networks)
+        → "connecting flashair"
+    - otherwise → the home SSID ('on "Hangar-WiFi"'), or "no wifi" if the
+        radio is genuinely down outside a card session.
+    """
+    on_card = bool(
+        flashair_pattern and ssid and flashair_pattern.lower() in ssid.lower()
+    )
+    if on_card or stage in _ON_CARD_STAGES:
+        return ("connected flashair", COLOR["ssid_flashair"])
+    if stage == "scanning" and not ssid:
+        return ("connecting flashair", COLOR["ssid_flashair"])
+    label = f'on "{ssid}"' if ssid else "no wifi"
+    return (label, ssid_color(ssid, flashair_pattern))
+
+
 def hvac_label(hvac):
     """Returns (label, color) for the HVAC footer, or (None, None) if HVAC is off / not configured."""
     if hvac is None:
@@ -376,11 +407,11 @@ def render(state, flashair_ssid_pattern=None):
         # Absent key (v0 contract) → suppress indicator. None value (v1, wifi
         # actually down) → "no wifi" in red.
         if "current_ssid" in fa:
-            ssid = fa["current_ssid"]
-            ssid_label = f'on "{ssid}"' if ssid else "no wifi"
+            ssid_label, ssid_lbl_color = _ssid_indicator(
+                fa["current_ssid"], fa.get("stage", "idle"),
+                flashair_ssid_pattern)
             d.text((100, 150), "·", fill=COLOR["very_dim"], font=f_label)
-            d.text((115, 150), ssid_label,
-                   fill=ssid_color(ssid, flashair_ssid_pattern), font=f_label)
+            d.text((115, 150), ssid_label, fill=ssid_lbl_color, font=f_label)
 
         age = now - fa.get("epoch", now)
         fresh_text = f"updated {fmt_age(age)} ago"
@@ -479,6 +510,8 @@ if __name__ == "__main__":
         "idle_done":           {**BASE, "flashair": fa_state(
             "idle", last_sync_epoch=NOW - 90, last_sync_files_n=7,
             last_shot_sync_epoch=NOW - 80, last_shot_sync_files_n=5)},
+        "connecting":          {**BASE, "flashair": fa_state(
+            "scanning", current_ssid=None)},
         "downloading_logs":    {**BASE, "flashair": fa_state(
             "downloading_logs", current_ssid="FlashAir-Card",
             files_done=3, files_total=7,

--- a/display.py
+++ b/display.py
@@ -232,6 +232,17 @@ def flashair_lines(fa):
                 COLOR["flash_idle"], ago, None, False)
     if stage == "scanning":
         return ("scanning card", COLOR["flash_active"], None, None, False)
+    if stage == "checking_logs":
+        # The ~90s stability poll on the newest CSV — nothing downloads yet
+        # (confirming the avionics finished writing it). Distinct from
+        # "downloading 0 of N" so a single-log sync doesn't look hung. No
+        # progress bar: the wait is time-based, not per-file; the heartbeat
+        # keeps "updated Xs ago" fresh as the liveness signal.
+        shot_word = "shot" if session_shots_n == 1 else "shots"
+        ctx = f"{session_shots_n} {shot_word} queued" if session_shots_n else None
+        log_word = "log" if ft == 1 else "logs"
+        head = f"checking {ft} {log_word}…" if ft else "checking log…"
+        return (head, COLOR["flash_active"], "making sure it's fully written", ctx, False)
     if stage == "downloading_logs":
         shot_word = "shot" if session_shots_n == 1 else "shots"
         ctx = f"{session_shots_n} {shot_word} queued" if session_shots_n else None
@@ -512,6 +523,11 @@ if __name__ == "__main__":
             last_shot_sync_epoch=NOW - 80, last_shot_sync_files_n=5)},
         "connecting":          {**BASE, "flashair": fa_state(
             "scanning", current_ssid=None)},
+        "checking_logs":       {**BASE, "flashair": fa_state(
+            "checking_logs", current_ssid="FlashAir-Card",
+            files_done=0, files_total=1,
+            session_csv_n=1, session_shots_n=8,
+            current_file=None)},
         "downloading_logs":    {**BASE, "flashair": fa_state(
             "downloading_logs", current_ssid="FlashAir-Card",
             files_done=3, files_total=7,


### PR DESCRIPTION
Companion to flashair-sync [#13](https://github.com/leithl/flashair-sync/pull/13). Both came out of diagnosing the 2026-05-29 sync (phone video of the OLED). This is the **display** side — the engine fixes (tally, stability heartbeat) live in flashair-sync.

## 1. `checking_logs` stage rendered distinctly
flashair-sync now emits a `checking_logs` stage during the ~90s CSV stability poll (nothing transfers during it). The OLED renders it as **"checking N log…" / "making sure it's fully written"** (no progress bar) instead of sitting on `downloading 0 of 1 logs` for 90s, which made a single-log sync look hung.

## 2. "connecting flashair" / "connected flashair" instead of raw SSID + "no wifi"
While the radio hops onto the card it briefly reports a null SSID → rendered as an alarming red **"no wifi"** mid-sync. And on the card it showed the raw configured SSID (`on "flashair_ec21…"`), which is noise. `_ssid_indicator()` now shows:
- on the card / mid-transfer → **"connected flashair"** (amber)
- hopping on → **"connecting flashair"**
- otherwise → home SSID (unchanged), or "no wifi" if genuinely down off-card

## Preview mockups
`DISPLAY_PREVIEW_DIR=/tmp python3 display.py` — verified `connecting`, `checking_logs`, `downloading_logs` (now "connected flashair"), and `idle_done` (home WiFi unchanged) all render correctly. Two new demo states added.

## Notes
- Degrades gracefully if flashair-sync #13 isn't deployed yet: the `checking_logs` case simply never fires; the SSID indicator works regardless.
- Display-only (OLED); no web/CDN surface. CDN pins checked, all current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)