### PR TITLE
feat(display): motion-wake backlight (C4001 mmWave sensor)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,8 @@
 #      VCC->3.3V, GND->GND, SDA->GPIO2, SCL->GPIO3.  `i2cdetect -y 1` → 2a + 38.
 #   3. Install the lib: git clone https://github.com/DFRobot/DFRobot_C4001
 #      and put its python/raspberrypi dir on PYTHONPATH (or copy
-#      DFRobot_C4001.py next to display_loop.py).
+#      DFRobot_C4001.py next to display_loop.py). It also needs pyserial +
+#      smbus: sudo apt-get install -y python3-serial python3-smbus
 #   4. Aim/tune: `python3 display_loop.py --presence-test`
 #   5. Set PRESENCE_ENABLED=1 and `sudo systemctl restart display`.
 # PRESENCE_ENABLED=1

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,25 @@
 # TOUCH_X_INVERT=0
 # TOUCH_Y_INVERT=0
 # TOUCH_PRESSURE_THRESHOLD=150
+
+# ---------------------------------------------------------------------------
+# Motion-wake backlight (optional — DFRobot C4001 / SEN0610 mmWave sensor)
+# ---------------------------------------------------------------------------
+# Turns the panel backlight off when no one's in the hangar, back on when
+# motion is sensed (extends LED-backlight life, cuts heat). Off by default.
+# To enable:
+#   1. Move the panel's LED/backlight pin from VCC to BACKLIGHT_GPIO (GPIO18).
+#   2. Wire the C4001 to the SAME I2C bus the touch chip uses:
+#      VCC->3.3V, GND->GND, SDA->GPIO2, SCL->GPIO3.  `i2cdetect -y 1` → 2a + 38.
+#   3. Install the lib: git clone https://github.com/DFRobot/DFRobot_C4001
+#      and put its python/raspberrypi dir on PYTHONPATH (or copy
+#      DFRobot_C4001.py next to display_loop.py).
+#   4. Aim/tune: `python3 display_loop.py --presence-test`
+#   5. Set PRESENCE_ENABLED=1 and `sudo systemctl restart display`.
+# PRESENCE_ENABLED=1
+# PRESENCE_MODE=motion        # motion=12m moving (SPEED_MODE); presence=8m incl. still (EXIST_MODE)
+# PRESENCE_I2C_ADDR=0x2A
+# PRESENCE_I2C_BUS=1
+# IDLE_TIMEOUT_SECS=120       # backlight sleeps this long after last motion/touch (rolling timer)
+# BACKLIGHT_GPIO=18
+# BACKLIGHT_FADE_SECS=0.4     # fade duration; 0 = instant on/off

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,24 @@ Raspberry Pi airplane hangar controller. The web UI controls three independent d
 - `scripts/setup-wifi-bridge.sh` — optional one-shot installer for the AP+STA bridge that lets the Midea dongle pair on open hangar WiFi. See "WiFi bridge" below.
 - `templates/index.html` — Jinja2 template
 - `heater-flush.service` — systemd unit, flushes RAM DB to disk on commanded shutdown/reboot
+- `display.py` / `display_loop.py` / `display_state.py` — 3.5" SPI IPS dashboard (ST7796U via luma.lcd), driven by the `display.service` systemd unit; renders heater / HVAC / hangar temp / FlashAir status. Fed by `flashair.py` (reads the flashair-sync status file) and `touch.py` (FT6336U capacitive touch on I2C). **Not auto-reloaded by mod_wsgi — `sudo systemctl restart display` after changes.**
+- `presence.py` / `backlight.py` — optional motion-wake: a DFRobot C4001 mmWave sensor (I2C, shares the touch bus) turns the panel backlight off when the hangar's empty, on when motion is sensed. Opt-in via `PRESENCE_ENABLED`. See "Motion-wake backlight".
 
 ## Three independent controlled devices
 **Don't conflate these — they are physically and electrically separate systems.**
 1. **Engine-block heater** (`config.GPIO_PIN`=17) — relay on the airplane oil-pan heater. The original purpose of this project. Toggled by the web UI's "Heater" card and `?state=` query param.
 2. **Exhaust fan** (`config.FAN_GPIO_PIN`=27) — relay on a hangar exhaust fan with auto/on/off mode.
 3. **Hangar HVAC** — Durastar DRAW33F2A mini-split (Midea OEM) reached over the LAN via the Midea WiFi dongle (US-OSK105) using `msmart-ng` on TCP/6444. Controlled from the "Hangar HVAC" card. Has its own scheduling path through the same scheduler. All HVAC code lives in `hvac.py`; `config.py` and the heater code never touch it.
+
+## Motion-wake backlight (`presence.py` + `backlight.py`)
+Optional, opt-in via `PRESENCE_ENABLED=1`. Turns the dashboard backlight off when the hangar's empty, on when someone's there — saves LED-backlight hours + heat on the always-on panel.
+- **Sensor:** DFRobot C4001 / **SEN0610** (24GHz mmWave) on **I2C 0x2A**, sharing the FT6336U touch bus (touch is 0x38 — no clash, no extra GPIO). Needs the `DFRobot_C4001` Python lib on the Pi (`git clone https://github.com/DFRobot/DFRobot_C4001`, put `python/raspberrypi` on PYTHONPATH, or copy `DFRobot_C4001.py` next to `display_loop.py`).
+- **Backlight:** the panel's LED pin is moved off the always-on VCC jumper to **GPIO18** (hardware-PWM). `backlight.py` PWMs it via gpiozero (full-off when idle, short fade). If the LED pin draws >~16 mA, it needs an N-MOSFET (gate←GPIO18).
+- **Logic** (in `display_loop.py`): **rolling** idle timeout — `_last_activity` resets on every presence detection OR touch; backlight sleeps after `IDLE_TIMEOUT_SECS` (default 120) with neither. Default mode `motion` (SPEED_MODE, ~12 m, covers the hangar; a motionless person reads as no-target — the timeout bridges it). `presence` mode = EXIST_MODE (~8 m, holds still presence). While asleep the loop stops pushing frames and skips the data-driven fast refresh; wake does an immediate render.
+- **Tap-to-wake:** a tap on a dark screen only wakes it (swallowed); a tap on a lit screen toggles the heater as normal.
+- **Fail-safe:** an unwired/failed sensor (or missing lib) → backlight forced **ON**. Lazy imports mean the display runs fine without the sensor or lib, so the feature can never leave the hangar screen dark.
+- **Beam caveat:** the C4001's 12 m is a forward lobe (100°×80°, narrowing with distance) — full depth down the centerline, wide up close; a motionless person in a far corner that never crossed the beam may not register. Fine for wake-on-entry.
+- **Tune/verify:** `python3 display_loop.py --presence-test` dumps detected/range/speed for 30 s. `i2cdetect -y 1` should show `2a` + `38`. Deploy needs `sudo systemctl restart display` (the display service doesn't auto-reload).
 
 ## Storage
 **Hot-path writes MUST go to `/run` (tmpfs / RAM), not `/var/lib/heater` (SD card).** SD cards on a Pi Zero W have a limited write-cycle budget; this app runs every minute for years. Any new feature that writes more often than ~once a week belongs in `/run`. The accepted tradeoff: anything in `/run` is lost on unplanned power loss — for this hangar that's fine because the disk DB has data up to the last weekly flush, and the `heater-flush.service` systemd unit catches commanded reboots/shutdowns.

--- a/README.md
+++ b/README.md
@@ -305,6 +305,38 @@ If someone uses the physical IR remote while you're away, the dongle's reported 
 
 ---
 
+## Motion-wake backlight (optional)
+
+The 3.5" IPS dashboard runs 24/7. To save LED-backlight hours (and heat), an optional **DFRobot C4001 / SEN0610** 24 GHz mmWave sensor turns the backlight off when the hangar's empty and back on the moment it senses motion. IPS panels have no burn-in, so this is purely backlight longevity. Off by default — the display behaves normally until you enable it.
+
+### Hardware
+- **C4001 mmWave sensor** (~$13, [DFRobot SEN0610](https://www.dfrobot.com/product-2795.html)): 8 m presence / 12 m motion, 100°×80° beam, I²C + UART, −40…85 °C. The 12 m variant — *not* the 25 m SEN0609.
+- Wire it to the **same I²C bus the touch chip uses** (no extra GPIO): `VCC→3.3V, GND→GND, SDA→GPIO2, SCL→GPIO3`. Its address `0x2A` doesn't clash with the touch chip's `0x38`.
+- **Backlight:** move the panel's LED pin from VCC to **GPIO18**. If that pin draws more than ~16 mA, drive it through a small N-channel MOSFET (gate←GPIO18, drain←LED, source←GND) rather than directly.
+
+### Setup
+1. Install the sensor library on the Pi:
+   ```bash
+   git clone https://github.com/DFRobot/DFRobot_C4001
+   # put its python/raspberrypi dir on PYTHONPATH, or copy DFRobot_C4001.py
+   # next to display_loop.py
+   ```
+   `gpiozero` (for the backlight) ships with Raspberry Pi OS.
+2. Confirm both chips are on the bus: `i2cdetect -y 1` → shows `2a` and `38`.
+3. Aim and tune: `python3 display_loop.py --presence-test` prints detection/range for 30 s.
+4. Enable in `.env`, then restart the display service:
+   ```bash
+   PRESENCE_ENABLED=1
+   sudo systemctl restart display
+   ```
+
+### Behaviour
+- Backlight comes **on** the instant motion is sensed and **off** after `IDLE_TIMEOUT_SECS` (default 120 s) with no motion *and* no touch. The timer is **rolling** — every detection resets it, so it stays on the whole time you're moving around and only counts down from the last time you were seen.
+- **Tap-to-wake:** tapping a dark screen just wakes it; tapping a lit screen toggles the heater as usual.
+- **Fail-safe:** if the sensor is unwired, fails, or the library is missing, the backlight stays **on** — the feature can never leave the screen dark. All knobs (mode, timeout, fade, GPIO) are documented in `.env.example`.
+
+---
+
 ## Storage Architecture
 
 To minimise SD card writes on the Raspberry Pi, all per-minute data is written to a SQLite database in RAM (`/run/heater.db`, on tmpfs), not to the SD card. This file is flushed to disk weekly. The web UI reads from both the RAM and disk databases via SQLite's `ATTACH` so no data is ever lost between flushes.

--- a/README.md
+++ b/README.md
@@ -317,13 +317,14 @@ The 3.5" IPS dashboard runs 24/7. To save LED-backlight hours (and heat), an opt
 - **Backlight:** move the panel's LED pin from VCC to **GPIO18**. If that pin draws more than ~16 mA, drive it through a small N-channel MOSFET (gate←GPIO18, drain←LED, source←GND) rather than directly.
 
 ### Setup
-1. Install the sensor library on the Pi:
+1. Install the sensor library and its Python deps on the Pi:
    ```bash
    git clone https://github.com/DFRobot/DFRobot_C4001
    # put its python/raspberrypi dir on PYTHONPATH, or copy DFRobot_C4001.py
    # next to display_loop.py
+   sudo apt-get install -y python3-serial python3-smbus
    ```
-   `gpiozero` (for the backlight) ships with Raspberry Pi OS.
+   `DFRobot_C4001.py` imports `serial` (pyserial) and `smbus` at the top even on the I2C path, so both must be present. `gpiozero` (for the backlight) ships with Raspberry Pi OS.
 2. Confirm both chips are on the bus: `i2cdetect -y 1` → shows `2a` and `38`.
 3. Aim and tune: `python3 display_loop.py --presence-test` prints detection/range for 30 s.
 4. Enable in `.env`, then restart the display service:

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ If someone uses the physical IR remote while you're away, the dongle's reported 
 
 The 3.5" IPS dashboard runs 24/7. To save LED-backlight hours (and heat), an optional **DFRobot C4001 / SEN0610** 24 GHz mmWave sensor turns the backlight off when the hangar's empty and back on the moment it senses motion. IPS panels have no burn-in, so this is purely backlight longevity. Off by default — the display behaves normally until you enable it.
 
+> **Step-by-step wiring + install checklist:** [`docs/motion-wake-install.html`](docs/motion-wake-install.html) (open in a browser — interactive, progress saved locally).
+
 ### Hardware
 - **C4001 mmWave sensor** (~$13, [DFRobot SEN0610](https://www.dfrobot.com/product-2795.html)): 8 m presence / 12 m motion, 100°×80° beam, I²C + UART, −40…85 °C. The 12 m variant — *not* the 25 m SEN0609.
 - Wire it to the **same I²C bus the touch chip uses** (no extra GPIO): `VCC→3.3V, GND→GND, SDA→GPIO2, SCL→GPIO3`. Its address `0x2A` doesn't clash with the touch chip's `0x38`.

--- a/backlight.py
+++ b/backlight.py
@@ -1,0 +1,74 @@
+"""
+backlight.py — PWM control of the dashboard panel's LED/backlight pin.
+
+The 3.5" ST7796 board's LED pin is moved off the always-on VCC jumper onto
+BACKLIGHT_GPIO (default GPIO18, a hardware-PWM pin) so the display can sleep
+when no one's in the hangar — extending LED-backlight life and cutting heat.
+presence.py decides *when*; this just does on/off with a short fade.
+
+Lazy import of gpiozero so the module loads on macOS dev. If the pin can't be
+opened (gpiozero missing, not on a Pi), every call is a silent no-op and the
+panel stays however it's wired — i.e. on. The feature is fail-safe-open.
+
+Wiring: GPIO18 must drive the LED pin. If that pin is a logic-level backlight
+*enable* (common on these boards) a GPIO drives it directly; if it's the raw
+LED drawing more than ~16 mA, put an N-channel MOSFET between them
+(gate <- GPIO18, drain <- LED pin, source <- GND).
+"""
+
+import time
+
+GPIO_DEFAULT      = 18
+FADE_SECS_DEFAULT = 0.4
+_FADE_STEPS       = 16
+
+
+class Backlight:
+    def __init__(self, gpio=GPIO_DEFAULT, fade_secs=FADE_SECS_DEFAULT):
+        self.gpio = int(gpio)
+        self.fade_secs = float(fade_secs)
+        self._led = None
+        self.available = False
+        self._level = 1.0
+        try:
+            from gpiozero import PWMLED
+            self._led = PWMLED(self.gpio)
+            self._led.value = 1.0          # start on
+            self.available = True
+        except Exception as e:
+            print(f"backlight: GPIO{self.gpio} unavailable ({e}); "
+                  f"backlight left as-wired (on)")
+
+    def _ramp(self, target):
+        if not self.available:
+            return
+        target = max(0.0, min(1.0, float(target)))
+        if self.fade_secs <= 0:
+            self._led.value = target
+            self._level = target
+            return
+        start = self._level
+        for i in range(1, _FADE_STEPS + 1):
+            self._led.value = start + (target - start) * (i / _FADE_STEPS)
+            time.sleep(self.fade_secs / _FADE_STEPS)
+        self._level = target
+
+    def wake(self):
+        self._ramp(1.0)
+
+    def sleep(self):
+        self._ramp(0.0)
+
+    @property
+    def is_on(self):
+        return self._level > 0.0
+
+    def close(self):
+        # Leave the panel ON when the service stops — a dark panel on a
+        # stopped service looks broken.
+        try:
+            if self.available:
+                self._led.value = 1.0
+                self._led.close()
+        except Exception:
+            pass

--- a/display_loop.py
+++ b/display_loop.py
@@ -30,16 +30,20 @@ from pathlib import Path
 # Allow systemd to invoke us from any working directory.
 sys.path.insert(0, str(Path(__file__).parent))
 
+import backlight        # noqa: E402
 import config           # noqa: E402  (path-modifying import above)
 import display          # noqa: E402
 import display_state    # noqa: E402
 import flashair         # noqa: E402
+import presence         # noqa: E402
 
 
 UPDATE_INTERVAL_SECS      = 5
 UPDATE_INTERVAL_FAST_SECS = 1      # used while a 'Xs ago' counter is on screen
 TOUCH_POLL_INTERVAL_SECS  = 0.05   # 20 Hz touch polling between display refreshes
 TOUCH_DEBOUNCE_SECS      = 1.0     # ignore taps within this window of the last one
+PRESENCE_POLL_SECS       = 1.0     # how often to read the mmWave sensor (shared I2C bus)
+IDLE_TIMEOUT_DEFAULT_SECS = 120    # backlight sleeps this long after last presence/touch
 DRY_RUN_OUT              = Path("/tmp/display-current.png")
 
 # ST7796U control pins on the Haldzemo 3.5" board. The board's silkscreen
@@ -54,6 +58,8 @@ SPI_DEV  = 0    # SPI0 CE0 — display chip select (BCM 8, Display pin 3 / LCD_C
 _stop = False
 _redraw_now = False    # set by _poll_touch when an action fires; consumed by _sleep_with_touch
 _last_tap_epoch = 0.0
+_awake = True          # backlight + render state. Always True when motion-wake is off.
+_last_activity = 0.0   # epoch of last presence detection or touch — the rolling idle timer
 
 
 def _on_signal(_signum, _frame):
@@ -160,17 +166,19 @@ def _toggle_heater():
         sys.stderr.write(f"display: heater toggle failed: {e}\n")
 
 
-def _poll_touch(touch_reader):
-    """One tick of touch polling. Triggers heater toggle if a debounced
-    tap lands inside HEATER_BUTTON_RECT.
+def _poll_touch(touch_reader, bl=None):
+    """One tick of touch polling.
 
-    Capacitive controllers do their own debouncing and only report active
-    contacts, so the per-poll cost is one I2C block-read returning quickly
-    when no finger is on the panel. Coordinates come back pre-calibrated
-    in 480×320 screen space — direct hit-test against HEATER_BUTTON_RECT,
-    no scaling needed.
+    A tap is always 'activity' (resets the idle timer). If the screen is
+    asleep, the tap only wakes it — swallowed so it doesn't also toggle the
+    heater (tap-to-wake, then tap-to-act, like a phone). When awake, a tap
+    inside HEATER_BUTTON_RECT toggles the engine-block heater.
+
+    Capacitive controllers debounce internally and only report active
+    contacts, so the per-poll cost is one quick I2C block-read. Coordinates
+    come back pre-calibrated in 480×320 space — direct hit-test, no scaling.
     """
-    global _last_tap_epoch
+    global _last_tap_epoch, _redraw_now, _last_activity
     try:
         pt = touch_reader.read_touch()
     except Exception as e:
@@ -181,14 +189,66 @@ def _poll_touch(touch_reader):
     now = time.time()
     if now - _last_tap_epoch < TOUCH_DEBOUNCE_SECS:
         return  # still in cooldown from previous tap
+    _last_tap_epoch = now
+    _last_activity = now
+
+    # Tap-to-wake: a tap on a sleeping screen only wakes it (swallowed).
+    if bl is not None and not _awake:
+        _wake(bl)
+        return
 
     x_px, y_px = pt
     import touch  # local module; cheap re-import is cached
     if touch.point_in_rect(x_px, y_px, display.HEATER_BUTTON_RECT):
-        global _redraw_now
-        _last_tap_epoch = now
         _toggle_heater()
         _redraw_now = True   # wake _sleep_with_touch so the button color flips immediately
+
+
+def _wake(bl):
+    """Wake the screen: backlight on + force an immediate redraw. No-op if
+    already awake."""
+    global _awake, _redraw_now
+    if _awake:
+        return
+    _awake = True
+    _redraw_now = True
+    if bl is not None:
+        bl.wake()
+
+
+def _sleep(bl):
+    """Sleep the screen: backlight off. The render loop stops pushing frames
+    while dark. No-op if already asleep."""
+    global _awake
+    if not _awake:
+        return
+    _awake = False
+    if bl is not None:
+        bl.sleep()
+
+
+def _apply_presence(presence_sensor, bl, idle_timeout):
+    """One presence poll. Wakes on detection; sleeps after `idle_timeout`
+    seconds with no presence AND no touch. Rolling — every detection resets
+    the timer, so walking around keeps it awake; the countdown only starts
+    from the last time anyone was seen.
+
+    An unavailable sensor (unwired, or failed mid-run) fails safe to
+    backlight-on — a dead sensor must never leave the hangar screen dark.
+    """
+    global _last_activity
+    if presence_sensor is None:
+        return  # motion-wake disabled → never manage the backlight
+    det = presence_sensor.detected()
+    if det is None:
+        _wake(bl)            # sensor dead → fail-safe on
+        return
+    now = time.time()
+    if det:
+        _last_activity = now
+        _wake(bl)
+    elif _awake and (now - _last_activity) > idle_timeout:
+        _sleep(bl)
 
 
 def _flashair_mtime_ns():
@@ -202,21 +262,31 @@ def _flashair_mtime_ns():
         return 0
 
 
-def _sleep_with_touch(secs, touch_reader, fa_mtime_baseline):
+def _sleep_with_touch(secs, touch_reader, fa_mtime_baseline,
+                      presence_sensor=None, bl=None,
+                      idle_timeout=IDLE_TIMEOUT_DEFAULT_SECS):
     """Sleep for `secs` total, polling touch every TOUCH_POLL_INTERVAL_SECS
-    and breaking early on SIGTERM, on a tap requesting an immediate redraw,
-    or when the FlashAir status file changes (daemon wrote new state)."""
+    and the mmWave sensor every PRESENCE_POLL_SECS. Breaks early on SIGTERM,
+    on a tap/motion requesting an immediate redraw, or — only while awake —
+    when the FlashAir status file changes (daemon wrote new state). While
+    asleep we keep polling presence but skip the data-driven refresh: nobody's
+    looking at a dark panel."""
     global _redraw_now
     chunks = int(secs / TOUCH_POLL_INTERVAL_SECS)
+    last_presence = 0.0
     for _ in range(chunks):
         if _stop:
             return
         if touch_reader is not None:
-            _poll_touch(touch_reader)
+            _poll_touch(touch_reader, bl)
+        now = time.time()
+        if presence_sensor is not None and (now - last_presence) >= PRESENCE_POLL_SECS:
+            last_presence = now
+            _apply_presence(presence_sensor, bl, idle_timeout)
         if _redraw_now:
             _redraw_now = False
             return
-        if _flashair_mtime_ns() != fa_mtime_baseline:
+        if _awake and _flashair_mtime_ns() != fa_mtime_baseline:
             return
         time.sleep(TOUCH_POLL_INTERVAL_SECS)
 
@@ -231,12 +301,33 @@ def _run_scan():
     touch.run_scan()
 
 
+def _run_presence_test():
+    """Print mmWave sensor readings for 30s so you can aim it and confirm
+    detection/range before enabling. Mirrors --scan for the touch chip."""
+    ps = presence.PresenceSensor()
+    if not ps.available:
+        sys.stderr.write(
+            "presence: sensor unavailable — check wiring, the DFRobot_C4001 "
+            "lib, and the I2C address (i2cdetect -y 1 should show 2a)\n"
+        )
+        return
+    print("presence: reading every 0.5s for 30s (Ctrl-C to stop)...")
+    end = time.time() + 30
+    while time.time() < end and not _stop:
+        print(ps.read_raw())
+        time.sleep(0.5)
+
+
 def main():
     signal.signal(signal.SIGTERM, _on_signal)
     signal.signal(signal.SIGINT, _on_signal)
 
     if "--scan" in sys.argv:
         _run_scan()
+        return
+
+    if "--presence-test" in sys.argv:
+        _run_presence_test()
         return
 
     device = None if _is_dry_run() else _open_device()
@@ -253,17 +344,40 @@ def main():
         # eyeball it". os._exit skips Python's cleanup chain.
         os._exit(0 if ok else 1)
 
+    # Motion-wake backlight (opt-in via PRESENCE_ENABLED=1). Both objects
+    # degrade to no-ops if their hardware/libs are missing, so the display
+    # behaves exactly as before when the sensor isn't wired.
+    env = config.load_env()
+    presence_sensor = bl = None
+    if env.get("PRESENCE_ENABLED") == "1" and not _is_dry_run():
+        bl = backlight.Backlight(
+            gpio=int(env.get("BACKLIGHT_GPIO", backlight.GPIO_DEFAULT)),
+            fade_secs=float(env.get("BACKLIGHT_FADE_SECS",
+                                    backlight.FADE_SECS_DEFAULT)),
+        )
+        presence_sensor = presence.PresenceSensor(env)
+    idle_timeout = int(env.get("IDLE_TIMEOUT_SECS", IDLE_TIMEOUT_DEFAULT_SECS))
+    global _awake, _last_activity
+    _awake = True
+    _last_activity = time.time()
+
     try:
         while not _stop:
-            _, interval = _push(device, ssid_pattern)
+            if _awake:
+                _, interval = _push(device, ssid_pattern)
+            else:
+                interval = UPDATE_INTERVAL_SECS  # dark — just poll for a wake
             # Capture mtime after rendering — the frame on screen reflects whatever
             # was in the file at that moment, so a later mtime means there's new
             # state to render.
             fa_mtime = _flashair_mtime_ns()
-            _sleep_with_touch(interval, touch_reader, fa_mtime)
+            _sleep_with_touch(interval, touch_reader, fa_mtime,
+                              presence_sensor, bl, idle_timeout)
     finally:
         if touch_reader is not None:
             touch_reader.close()
+        if bl is not None:
+            bl.close()
 
 
 if __name__ == "__main__":

--- a/docs/motion-wake-install.html
+++ b/docs/motion-wake-install.html
@@ -324,7 +324,7 @@ i2cdetect -y 1</code></pre>You should see <code>2a</code> (the C4001) and <code>
   <div class="step-body"><label for="i2">Get the DFRobot C4001 Python library and put it where <code>display_loop.py</code> can import it (it adds its own dir to <code>sys.path</code>, so dropping the file alongside it is simplest).<pre><code>cd /tmp
 git clone https://github.com/DFRobot/DFRobot_C4001
 sudo cp DFRobot_C4001/python/raspberrypi/DFRobot_C4001.py \
-        /usr/lib/cgi-bin/remote-switch/</code></pre>If the lib imports other files in that folder, copy those too. (Missing lib is harmless — the display just runs without motion-wake.)</label></div>
+        /usr/lib/cgi-bin/remote-switch/</code></pre>The library imports <code>serial</code> (pyserial) and <code>smbus</code> at the top even on the I2C path, so install both or the import fails with <code>No module named 'serial'</code>:<pre><code>sudo apt-get install -y python3-serial python3-smbus</code></pre>If the lib imports other files in that folder, copy those too. (Missing lib is harmless — the display just runs without motion-wake.)</label></div>
 </div>
 <div class="step">
   <input type="checkbox" id="i3">
@@ -428,8 +428,8 @@ sudo systemctl status display</code></pre>Status <code>active (running)</code>; 
     </tr>
     <tr>
       <td><code>presence: DFRobot_C4001 lib unavailable</code></td>
-      <td>Library not on the path</td>
-      <td>Copy <code>DFRobot_C4001.py</code> into <code>/usr/lib/cgi-bin/remote-switch/</code>.</td>
+      <td>Library file missing, or its <code>pyserial</code>/<code>smbus</code> deps aren't installed (the message names the missing one, e.g. <code>No module named 'serial'</code>)</td>
+      <td>Copy <code>DFRobot_C4001.py</code> into <code>/usr/lib/cgi-bin/remote-switch/</code>, and install the deps: <code>sudo apt-get install -y python3-serial python3-smbus</code>.</td>
     </tr>
     <tr>
       <td>Wakes/sleeps too eagerly</td>

--- a/docs/motion-wake-install.html
+++ b/docs/motion-wake-install.html
@@ -1,0 +1,505 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hangar motion-wake backlight — install</title>
+  <style>
+    :root {
+      --bg: #0d0e10;
+      --panel: #16181d;
+      --rule: #2a2d33;
+      --fg: #e6e7eb;
+      --fg-dim: #9b9ea6;
+      --fg-very-dim: #6a6d75;
+      --accent: #6ec8ff;
+      --warn: #ffb44a;
+      --bad: #ff6258;
+      --ok: #84d99c;
+      --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 1.5rem;
+      background: var(--bg);
+      color: var(--fg);
+      font: 15px/1.55 var(--sans);
+      max-width: 880px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    h1 {
+      font-size: 1.65rem;
+      margin: 0 0 0.25rem;
+    }
+    h2 {
+      font-size: 1.15rem;
+      margin: 2rem 0 0.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--rule);
+      color: var(--accent);
+    }
+    h3 {
+      font-size: 1rem;
+      margin: 1.25rem 0 0.5rem;
+      color: var(--fg-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .lede {
+      color: var(--fg-dim);
+      margin: 0 0 1.5rem;
+    }
+    code, pre, kbd {
+      font-family: var(--mono);
+      font-size: 0.9em;
+    }
+    code {
+      background: var(--panel);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+    pre {
+      background: var(--panel);
+      border: 1px solid var(--rule);
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      overflow-x: auto;
+      margin: 0.5rem 0 1rem;
+    }
+    pre code { background: none; padding: 0; }
+    .step {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.7rem;
+      margin: 0.4rem 0;
+      padding: 0.35rem 0;
+    }
+    .step input[type=checkbox] {
+      flex: 0 0 auto;
+      width: 22px;
+      height: 22px;
+      margin-top: 1px;
+      cursor: pointer;
+      accent-color: var(--ok);
+    }
+    .step-body {
+      flex: 1;
+      min-width: 0;
+    }
+    .step.done .step-body {
+      color: var(--fg-very-dim);
+      text-decoration: line-through;
+    }
+    .step.done pre, .step.done code {
+      opacity: 0.5;
+    }
+    .note {
+      border-left: 3px solid var(--warn);
+      background: var(--panel);
+      padding: 0.65rem 0.9rem;
+      margin: 0.75rem 0;
+      border-radius: 0 4px 4px 0;
+      font-size: 0.93em;
+    }
+    .note.danger { border-left-color: var(--bad); }
+    .note.tip    { border-left-color: var(--accent); }
+    .note strong { color: var(--warn); }
+    .note.danger strong { color: var(--bad); }
+    .note.tip strong    { color: var(--accent); }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0.5rem 0 1rem;
+      font-size: 0.93em;
+    }
+    th, td {
+      border-bottom: 1px solid var(--rule);
+      padding: 0.45rem 0.6rem;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { color: var(--fg-dim); font-weight: 600; font-size: 0.82em; text-transform: uppercase; letter-spacing: 0.05em; }
+    td code { font-size: 0.95em; }
+    .pinmap td:nth-child(1) { font-weight: 600; }
+    .pinmap td:nth-child(2),
+    .pinmap td:nth-child(3) { font-family: var(--mono); color: var(--accent); }
+    .pinmap tr.power td:nth-child(2),
+    .pinmap tr.power td:nth-child(3) { color: var(--warn); }
+    .pinmap tr.gnd td:nth-child(2),
+    .pinmap tr.gnd td:nth-child(3) { color: var(--fg-dim); }
+    .reset {
+      margin-top: 2.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--rule);
+      text-align: center;
+    }
+    .reset button {
+      background: var(--panel);
+      color: var(--fg-dim);
+      border: 1px solid var(--rule);
+      padding: 0.4rem 0.9rem;
+      border-radius: 4px;
+      font: inherit;
+      font-size: 0.85em;
+      cursor: pointer;
+    }
+    .reset button:hover {
+      background: var(--rule);
+      color: var(--fg);
+    }
+    .progress {
+      position: sticky;
+      top: 0;
+      background: var(--bg);
+      padding: 0.6rem 0;
+      margin: -1.5rem -1.5rem 1.5rem;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+      border-bottom: 1px solid var(--rule);
+      font-size: 0.85em;
+      color: var(--fg-dim);
+      z-index: 10;
+    }
+    .progress-bar {
+      height: 3px;
+      background: var(--rule);
+      border-radius: 2px;
+      margin-top: 0.35rem;
+      overflow: hidden;
+    }
+    .progress-bar > div {
+      height: 100%;
+      background: var(--ok);
+      transition: width 0.3s ease;
+    }
+    @media print {
+      .progress, .reset { display: none; }
+      body { color: black; background: white; max-width: none; }
+      h2 { color: black; border-top-color: #ccc; }
+      h3, .lede { color: #444; }
+      pre, code { background: #f4f4f4; color: black; }
+      .note { background: #fafafa; }
+      .step.done .step-body { text-decoration: none; color: #888; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="progress">
+  <span id="progress-text">0 of 0 steps done</span>
+  <div class="progress-bar"><div id="progress-fill" style="width: 0%"></div></div>
+</div>
+
+<h1>Hangar motion-wake backlight — install</h1>
+<p class="lede">
+  Adds a <strong>DFRobot C4001 (SEN0610)</strong> 24&nbsp;GHz mmWave sensor so the
+  3.5" dashboard's backlight sleeps when the hangar's empty and wakes on motion.
+  Assumes the <a href="display-install.html">display is already installed</a> and
+  running. Check off each step — progress is saved in this browser.
+</p>
+
+<div class="note tip">
+  <strong>Why bother:</strong> the IPS panel has no burn-in, so this is purely
+  about LED-backlight hours + heat on an always-on display. The feature is
+  opt-in (<code>PRESENCE_ENABLED=1</code>) and <strong>fail-safe</strong> — an
+  unwired or dead sensor leaves the backlight <em>on</em>, never dark.
+</div>
+
+<h2>Parts check</h2>
+<div class="step">
+  <input type="checkbox" id="p1">
+  <div class="step-body"><label for="p1"><strong>DFRobot Gravity C4001 (SEN0610, 12&nbsp;m)</strong> — the "12 Meters, I2C &amp; UART" variant, <em>not</em> the 25&nbsp;m SEN0609. Ships with a Gravity 4-pin (PH2.0) cable.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="p2">
+  <div class="step-body"><label for="p2"><strong>Female-to-female jumper wires</strong> — 4 for the sensor (or use the Gravity cable + adapters), plus the one already on the panel's LED pin.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="p3">
+  <div class="step-body"><label for="p3"><strong>(Maybe) a logic-level N-MOSFET</strong> (2N7000 / AO3400) + a 10&nbsp;kΩ resistor — only if the backlight pin draws too much for a GPIO (see the drive test below). Worth having on hand.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="p4">
+  <div class="step-body"><label for="p4">Sensor inspected — no bent pins, board reads "C4001" / "DFR1156" / SEN0610.</label></div>
+</div>
+
+<h2>Set the board to I2C mode</h2>
+<p>The C4001 talks I2C <em>or</em> UART, selected on the board. We use I2C so it can share the bus the touch chip already uses (no extra GPIO).</p>
+<div class="step">
+  <input type="checkbox" id="m1">
+  <div class="step-body"><label for="m1">Set the I2C/UART selector to <strong>I2C</strong> (DFRobot Gravity C4001 has a small slide switch / solder-pad — check the silkscreen near the connector). If yours has no switch it defaults to I2C.</label></div>
+</div>
+
+<h2>Power down before wiring</h2>
+<div class="note danger">
+  <strong>Important:</strong> shut the Pi cleanly before touching the header. GPIO isn't hot-pluggable, and a one-pin slip shorts 3V3 → fry.
+</div>
+<div class="step">
+  <input type="checkbox" id="d1">
+  <div class="step-body"><label for="d1">SSH in and shut down cleanly.<pre><code>ssh pi.vpn
+sudo systemctl poweroff</code></pre>Wait for the green ACT LED to stop blinking, then unplug power.</label></div>
+</div>
+
+<h2>Wiring — sensor onto the I2C bus</h2>
+<p>The C4001 hangs on the <strong>same two I2C lines as the touch chip</strong> — wire it in parallel. Address <code>0x2A</code> doesn't clash with the touch chip's <code>0x38</code>. Pi Zero W 40-pin header; <strong>3.3V logic and 3V3 power throughout</strong>.</p>
+
+<table class="pinmap">
+  <thead>
+    <tr><th>C4001 pin</th><th>Pi BCM</th><th>Pi header pin</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr class="power"><td>VCC</td><td>3V3</td><td>1 / 17</td><td>Power. Both 3V3 pins are taken (DS18B20 on 1, panel on 17) — tap the breadboard 3V3 rail you already have.</td></tr>
+    <tr class="gnd"><td>GND</td><td>GND</td><td>6 / 9 / 14 / …</td><td>Any GND pin (or the breadboard GND rail).</td></tr>
+    <tr><td>SDA</td><td>BCM 2</td><td>3</td><td>Shared with the FT6336U touch — wire in parallel onto the same line.</td></tr>
+    <tr><td>SCL</td><td>BCM 3</td><td>5</td><td>Shared with touch.</td></tr>
+    <tr style="opacity:0.5"><td>OUT</td><td>—</td><td>—</td><td>Leave unconnected. (Digital presence pin — only used as a fallback if I2C ever misbehaves.)</td></tr>
+    <tr style="opacity:0.5"><td>TX / RX</td><td>—</td><td>—</td><td>Leave unconnected — UART unused.</td></tr>
+  </tbody>
+</table>
+<div class="note tip">
+  <strong>Power it at 3.3V, not 5V.</strong> The board's OUT/IO pins then swing 3.3V (Pi-safe). The I2C lines are open-drain and pulled to 3.3V by the Pi regardless, but keeping VCC at 3.3V keeps everything unambiguous.
+</div>
+
+<h2>Wiring — move the backlight to GPIO18</h2>
+<p>The panel's LED/backlight pin is currently jumpered to the 3V3 rail (always on). Move that jumper's Pi end to <strong>GPIO18</strong> so software can switch it.</p>
+
+<table class="pinmap">
+  <thead>
+    <tr><th>Panel pin</th><th>From</th><th>To (Pi BCM)</th><th>Pi header pin</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>LED / BL</td><td>3V3 rail</td><td>BCM 18</td><td>12</td></tr>
+  </tbody>
+</table>
+
+<div class="note danger">
+  <strong>Drive test first — does the LED pin need a transistor?</strong> A GPIO can source only ~16&nbsp;mA. Two ways to check before committing:
+  <ol>
+    <li><strong>Measure:</strong> multimeter in series on the old VCC→LED jumper, powered on. <code>&lt; ~16&nbsp;mA</code> → GPIO drives it directly (it's a logic-level enable). More than that → it needs a transistor.</li>
+    <li><strong>Observe:</strong> after wiring to GPIO18, run the on/off test (below). Full brightness when on → direct drive is fine. Noticeably dim → too much current for the GPIO.</li>
+  </ol>
+  <strong>If it needs a transistor:</strong> a logic-level N-MOSFET (2N7000 / AO3400) low-side on the backlight's ground return — gate ← GPIO18 (100&nbsp;Ω in series), source ← GND, drain ← the LED/return pin, 10&nbsp;kΩ gate→GND pulldown. PWM on the gate then dims as normal.
+</div>
+
+<div class="step">
+  <input type="checkbox" id="w1">
+  <div class="step-body"><label for="w1">Sensor's 4 wires connected (VCC, GND, SDA→pin&nbsp;3, SCL→pin&nbsp;5), double-checked against the table.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="w2">
+  <div class="step-body"><label for="w2">Backlight LED jumper moved from the 3V3 rail to <strong>GPIO18 / pin&nbsp;12</strong>.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="w3">
+  <div class="step-body"><label for="w3">No wire touching an adjacent header pin (a one-pin slip grounds 3V3).</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="w4">
+  <div class="step-body"><label for="w4">Pi powered back on, green ACT LED blinking normally. <strong>The screen will be dark until step "First light"</strong> — that's expected now that LED is on a GPIO that defaults low.</label></div>
+</div>
+
+<h2>Confirm both chips on the bus</h2>
+<p>I2C is already enabled (the touch chip uses it) — no <code>raspi-config</code> needed.</p>
+<div class="step">
+  <input type="checkbox" id="b1">
+  <div class="step-body"><label for="b1">Both addresses show up.<pre><code>ssh pi.vpn
+i2cdetect -y 1</code></pre>You should see <code>2a</code> (the C4001) and <code>38</code> (the touch chip) in the grid. If <code>2a</code> is missing, re-check SDA/SCL and the I2C-mode switch.</label></div>
+</div>
+
+<h2>Install the sensor library</h2>
+<div class="step">
+  <input type="checkbox" id="i1">
+  <div class="step-body"><label for="i1"><code>gpiozero</code> (the backlight driver) ships with Raspberry Pi OS — confirm it imports.<pre><code>python3 -c "import gpiozero; print('ok')"</code></pre></label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="i2">
+  <div class="step-body"><label for="i2">Get the DFRobot C4001 Python library and put it where <code>display_loop.py</code> can import it (it adds its own dir to <code>sys.path</code>, so dropping the file alongside it is simplest).<pre><code>cd /tmp
+git clone https://github.com/DFRobot/DFRobot_C4001
+sudo cp DFRobot_C4001/python/raspberrypi/DFRobot_C4001.py \
+        /usr/lib/cgi-bin/remote-switch/</code></pre>If the lib imports other files in that folder, copy those too. (Missing lib is harmless — the display just runs without motion-wake.)</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="i3">
+  <div class="step-body"><label for="i3">Pull the branch with <code>presence.py</code> / <code>backlight.py</code> / the updated <code>display_loop.py</code> (as the <code>leith</code> user — never <code>sudo git pull</code>, it changes ownership).<pre><code>cd /usr/lib/cgi-bin/remote-switch
+git pull</code></pre></label></div>
+</div>
+
+<h2>Aim &amp; tune</h2>
+<p>The mmWave beam is a forward lobe — long down the centerline, wide up close. Point it down the length of the hangar. Use the live readout to confirm coverage and pick the mounting angle.</p>
+<div class="step">
+  <input type="checkbox" id="t1">
+  <div class="step-body"><label for="t1">Run the test dump (no service changes needed — it reads the sensor directly):<pre><code>cd /usr/lib/cgi-bin/remote-switch
+python3 display_loop.py --presence-test</code></pre>Prints a line every 0.5s for 30s, e.g. <code>{'available': True, 'detected': True, 'targets': 1, 'range': 4.2, 'speed': 0.8}</code>.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="t2">
+  <div class="step-body"><label for="t2">Walk the hangar while it runs — confirm <code>detected</code> flips to <code>True</code> as far out as you need (out toward the door for the full ~12&nbsp;m). Adjust the mount angle and re-run until coverage looks right.</label></div>
+</div>
+<div class="note tip">
+  <strong>Default mode is <code>motion</code></strong> (12&nbsp;m, whole hangar). A motionless person reads as no-target — the rolling idle timeout bridges that. Switch to <code>PRESENCE_MODE=presence</code> for still-presence holding, but only to ~8&nbsp;m.
+</div>
+
+<h2>Enable it</h2>
+<div class="step">
+  <input type="checkbox" id="e1">
+  <div class="step-body"><label for="e1">Add the knobs to <code>.env</code> (only <code>PRESENCE_ENABLED=1</code> is required; the rest are defaults shown for reference):<pre><code>sudo nano /usr/lib/cgi-bin/remote-switch/.env</code></pre><pre><code>PRESENCE_ENABLED=1
+# PRESENCE_MODE=motion        # motion=12m | presence=8m incl. still
+# IDLE_TIMEOUT_SECS=120       # rolling: resets on every motion/touch
+# BACKLIGHT_GPIO=18
+# BACKLIGHT_FADE_SECS=0.4     # 0 = instant
+# PRESENCE_I2C_ADDR=0x2A</code></pre></label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="e2">
+  <div class="step-body"><label for="e2">Restart the display service (it does <em>not</em> auto-reload).<pre><code>sudo systemctl restart display
+sudo systemctl status display</code></pre>Status <code>active (running)</code>; the journal should print <code>presence: C4001 ready (mode=motion, addr=0x2a)</code> and <code>backlight: …</code> only if there's a problem.</label></div>
+</div>
+
+<h2>First light &amp; behaviour check</h2>
+<div class="step">
+  <input type="checkbox" id="v1">
+  <div class="step-body"><label for="v1"><strong>Wake:</strong> walk in front of the sensor — the backlight fades on within ~1s and the dashboard shows the current frame.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="v2">
+  <div class="step-body"><label for="v2"><strong>Sleep:</strong> step out of range and stay clear — the backlight fades off after <code>IDLE_TIMEOUT_SECS</code> (default 120s). Watch the journal: <code>journalctl -fu display</code>.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="v3">
+  <div class="step-body"><label for="v3"><strong>Rolling timer:</strong> walk around continuously for &gt;2&nbsp;min — it should stay on the whole time (each detection resets the countdown).</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="v4">
+  <div class="step-body"><label for="v4"><strong>Tap-to-wake:</strong> with the screen dark, tap it — it should just wake (the heater must <em>not</em> toggle). Tap again once it's lit — now it toggles the heater as normal.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="v5">
+  <div class="step-body"><label for="v5"><strong>Fail-safe:</strong> unplug the sensor's SDA (or power) briefly — within ~10s the backlight should force <em>on</em> and stay on (a dead sensor never leaves the screen dark). Reconnect to resume normal behaviour.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="v6">
+  <div class="step-body"><label for="v6"><strong>Reboot test:</strong> <code>sudo reboot</code> — after boot the screen comes up on (then sleeps after the timeout if the hangar's empty).</label></div>
+</div>
+
+<h2>Tuning reference</h2>
+<table>
+  <thead><tr><th>Knob (.env)</th><th>Default</th><th>What it does</th></tr></thead>
+  <tbody>
+    <tr><td><code>PRESENCE_ENABLED</code></td><td>off</td><td><code>1</code> turns the whole feature on. Unset → display behaves as before (always on).</td></tr>
+    <tr><td><code>PRESENCE_MODE</code></td><td><code>motion</code></td><td><code>motion</code> = SPEED_MODE, ~12&nbsp;m moving targets. <code>presence</code> = EXIST_MODE, ~8&nbsp;m incl. still.</td></tr>
+    <tr><td><code>IDLE_TIMEOUT_SECS</code></td><td><code>120</code></td><td>Backlight sleeps this long after the last motion <em>or</em> touch. Rolling.</td></tr>
+    <tr><td><code>BACKLIGHT_GPIO</code></td><td><code>18</code></td><td>Pin driving the LED. Hardware-PWM on 18/12/13/19.</td></tr>
+    <tr><td><code>BACKLIGHT_FADE_SECS</code></td><td><code>0.4</code></td><td>Fade duration on wake/sleep. <code>0</code> = instant.</td></tr>
+    <tr><td><code>PRESENCE_I2C_ADDR</code></td><td><code>0x2A</code></td><td>C4001 I2C address (some boards ship <code>0x2B</code>).</td></tr>
+  </tbody>
+</table>
+
+<h2>Troubleshooting cheat-sheet</h2>
+<table>
+  <thead><tr><th>Symptom</th><th>Likely cause</th><th>Fix</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>Screen never sleeps</td>
+      <td>Sensor unavailable → fail-safe-on, or constant detections</td>
+      <td>Journal: <code>presence: … unavailable</code> means lib/wiring. Otherwise something's moving in-beam (HVAC airflow?) — narrow the aim.</td>
+    </tr>
+    <tr>
+      <td>Screen never wakes</td>
+      <td>Sensor reading but mis-aimed, or backlight not switching</td>
+      <td><code>--presence-test</code> to confirm detection; then check the LED pin actually moved to GPIO18 and the drive test passed.</td>
+    </tr>
+    <tr>
+      <td><code>2a</code> missing from <code>i2cdetect</code></td>
+      <td>SDA/SCL swapped, mode switch on UART, or no power</td>
+      <td>Re-check pins 3/5, set the board to I2C, confirm 3V3 on VCC.</td>
+    </tr>
+    <tr>
+      <td>Backlight dim, not full</td>
+      <td>LED pin sources more than a GPIO can drive</td>
+      <td>Add the N-MOSFET (see the drive-test note).</td>
+    </tr>
+    <tr>
+      <td><code>presence: DFRobot_C4001 lib unavailable</code></td>
+      <td>Library not on the path</td>
+      <td>Copy <code>DFRobot_C4001.py</code> into <code>/usr/lib/cgi-bin/remote-switch/</code>.</td>
+    </tr>
+    <tr>
+      <td>Wakes/sleeps too eagerly</td>
+      <td>Timeout too short, or beam catching the apron through an open door</td>
+      <td>Raise <code>IDLE_TIMEOUT_SECS</code>; aim away from the door line.</td>
+    </tr>
+    <tr>
+      <td>Tapping a dark screen toggles the heater</td>
+      <td>Running an old <code>display_loop.py</code> without tap-to-wake</td>
+      <td><code>git pull</code> the branch with this feature, restart <code>display</code>.</td>
+    </tr>
+    <tr>
+      <td>Heater toggle / display dies after enabling</td>
+      <td>—</td>
+      <td>Set <code>PRESENCE_ENABLED</code> unset and restart: the feature is fully opt-in, so this isolates it instantly.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Files in this repo</h2>
+<ul>
+  <li><code>presence.py</code> — DFRobot C4001 I2C wrapper; <code>detected() → bool|None</code></li>
+  <li><code>backlight.py</code> — gpiozero PWM on the LED GPIO; <code>wake()</code> / <code>sleep()</code> with fade</li>
+  <li><code>display_loop.py</code> — wake/sleep state machine + <code>--presence-test</code></li>
+  <li><code>.env.example</code> — the <code>PRESENCE_*</code> / <code>BACKLIGHT_*</code> knobs</li>
+  <li><code>docs/motion-wake-install.html</code> — this file</li>
+</ul>
+
+<div class="reset">
+  <button id="reset-btn">Reset progress</button>
+</div>
+
+<script>
+(function() {
+  const KEY = 'hangar-motion-wake-install-progress';
+  const boxes = document.querySelectorAll('input[type=checkbox]');
+  const text = document.getElementById('progress-text');
+  const fill = document.getElementById('progress-fill');
+  const reset = document.getElementById('reset-btn');
+
+  // Restore
+  try {
+    const saved = JSON.parse(localStorage.getItem(KEY) || '{}');
+    boxes.forEach(b => {
+      if (saved[b.id]) {
+        b.checked = true;
+        b.closest('.step').classList.add('done');
+      }
+    });
+  } catch (e) {}
+
+  function update() {
+    const state = {};
+    let done = 0;
+    boxes.forEach(b => {
+      state[b.id] = b.checked;
+      if (b.checked) done++;
+      b.closest('.step').classList.toggle('done', b.checked);
+    });
+    try { localStorage.setItem(KEY, JSON.stringify(state)); } catch (e) {}
+    text.textContent = `${done} of ${boxes.length} steps done`;
+    fill.style.width = `${(done / boxes.length) * 100}%`;
+  }
+
+  boxes.forEach(b => b.addEventListener('change', update));
+  reset.addEventListener('click', () => {
+    if (confirm('Reset all checkboxes?')) {
+      try { localStorage.removeItem(KEY); } catch (e) {}
+      boxes.forEach(b => { b.checked = false; });
+      update();
+    }
+  });
+  update();
+})();
+</script>
+
+</body>
+</html>

--- a/docs/motion-wake-install.html
+++ b/docs/motion-wake-install.html
@@ -226,11 +226,18 @@
   <div class="step-body"><label for="p4">Sensor inspected — no bent pins, board reads "C4001" / "DFR1156" / SEN0610.</label></div>
 </div>
 
-<h2>Set the board to I2C mode</h2>
-<p>The C4001 talks I2C <em>or</em> UART, selected on the board. We use I2C so it can share the bus the touch chip already uses (no extra GPIO).</p>
+<h2>Set the DIP switches — I2C mode + address</h2>
+<p>The C4001 talks I2C <em>or</em> UART, set by <strong>two DIP switches on the back of the board</strong> (not a slide switch — the silkscreen labels each one). We use I2C so the sensor shares the bus the touch chip already uses (no extra GPIO).</p>
 <div class="step">
   <input type="checkbox" id="m1">
-  <div class="step-body"><label for="m1">Set the I2C/UART selector to <strong>I2C</strong> (DFRobot Gravity C4001 has a small slide switch / solder-pad — check the silkscreen near the connector). If yours has no switch it defaults to I2C.</label></div>
+  <div class="step-body"><label for="m1"><strong>Mode switch → I2C.</strong> Set the <code>I2C / UART</code> switch to the <strong>I2C</strong> side. This is the one that matters — DFRobot ships these to be set by hand, so <em>don't assume it's already on I2C</em>. On UART the sensor never appears on the bus and <code>i2cdetect</code> won't see it.</label></div>
+</div>
+<div class="step">
+  <input type="checkbox" id="m2">
+  <div class="step-body"><label for="m2"><strong>Address switch → <code>0x2A</code>.</strong> The second switch picks the I2C address, <code>0x2A</code> or <code>0x2B</code>. Leave it on the <code>0x2A</code> default — that's what the code expects.</label></div>
+</div>
+<div class="note tip">
+  <strong>If <code>i2cdetect</code> later shows <code>2b</code> instead of <code>2a</code></strong>, don't reopen the case — just set <code>PRESENCE_I2C_ADDR=0x2B</code> in <code>.env</code> and restart the display. The address switch isn't critical; the mode switch is.
 </div>
 
 <h2>Power down before wiring</h2>
@@ -251,16 +258,14 @@ sudo systemctl poweroff</code></pre>Wait for the green ACT LED to stop blinking,
     <tr><th>C4001 pin</th><th>Pi BCM</th><th>Pi header pin</th><th>Notes</th></tr>
   </thead>
   <tbody>
-    <tr class="power"><td>VCC</td><td>3V3</td><td>1 / 17</td><td>Power. Both 3V3 pins are taken (DS18B20 on 1, panel on 17) — tap the breadboard 3V3 rail you already have.</td></tr>
-    <tr class="gnd"><td>GND</td><td>GND</td><td>6 / 9 / 14 / …</td><td>Any GND pin (or the breadboard GND rail).</td></tr>
-    <tr><td>SDA</td><td>BCM 2</td><td>3</td><td>Shared with the FT6336U touch — wire in parallel onto the same line.</td></tr>
-    <tr><td>SCL</td><td>BCM 3</td><td>5</td><td>Shared with touch.</td></tr>
-    <tr style="opacity:0.5"><td>OUT</td><td>—</td><td>—</td><td>Leave unconnected. (Digital presence pin — only used as a fallback if I2C ever misbehaves.)</td></tr>
-    <tr style="opacity:0.5"><td>TX / RX</td><td>—</td><td>—</td><td>Leave unconnected — UART unused.</td></tr>
+    <tr class="power"><td>+ (VCC)</td><td>3V3</td><td>1 / 17</td><td>Power. Both 3V3 pins are taken (DS18B20 on 1, panel on 17) — tap the breadboard 3V3 rail you already have.</td></tr>
+    <tr class="gnd"><td>− (GND)</td><td>GND</td><td>6 / 9 / 14 / …</td><td>Any GND pin (or the breadboard GND rail).</td></tr>
+    <tr><td>D/T (SDA)</td><td>BCM 2</td><td>3</td><td>Data line. Shared with the FT6336U touch — wire in parallel onto the same line.</td></tr>
+    <tr><td>C/R (SCL)</td><td>BCM 3</td><td>5</td><td>Clock line. Shared with touch.</td></tr>
   </tbody>
 </table>
 <div class="note tip">
-  <strong>Power it at 3.3V, not 5V.</strong> The board's OUT/IO pins then swing 3.3V (Pi-safe). The I2C lines are open-drain and pulled to 3.3V by the Pi regardless, but keeping VCC at 3.3V keeps everything unambiguous.
+  <strong>The board prints <code>+ &minus; C/R D/T</code>, not SDA/SCL.</strong> In I2C mode <code>D/T</code> is data (SDA) and <code>C/R</code> is clock (SCL) — the same two pins double as UART TX/RX when the mode switch is on UART. It's a 4-pin Gravity connector: there's no separate OUT/IO pin to leave unconnected. <strong>Power it at 3.3V, not 5V</strong> (the board accepts either) so its logic stays Pi-safe.
 </div>
 
 <h2>Wiring — move the backlight to GPIO18</h2>
@@ -286,7 +291,7 @@ sudo systemctl poweroff</code></pre>Wait for the green ACT LED to stop blinking,
 
 <div class="step">
   <input type="checkbox" id="w1">
-  <div class="step-body"><label for="w1">Sensor's 4 wires connected (VCC, GND, SDA→pin&nbsp;3, SCL→pin&nbsp;5), double-checked against the table.</label></div>
+  <div class="step-body"><label for="w1">Sensor's 4 wires connected (<code>+</code>→3V3, <code>−</code>→GND, <code>D/T</code>→pin&nbsp;3, <code>C/R</code>→pin&nbsp;5), double-checked against the table.</label></div>
 </div>
 <div class="step">
   <input type="checkbox" id="w2">

--- a/presence.py
+++ b/presence.py
@@ -1,0 +1,109 @@
+"""
+presence.py — DFRobot C4001 (SEN0610) 24GHz mmWave presence/motion sensor.
+
+Wakes the dashboard backlight when someone's in the hangar. Lives on the SAME
+I2C bus as the FT6336U touch chip — different address (0x2A vs touch's 0x38),
+so it adds no GPIO. Read about once per second from display_loop's poll cycle.
+
+Mirrors touch.py: the vendor lib is imported lazily so this module loads fine
+on macOS dev / a Pi without the sensor wired, and every read failure degrades
+to "unavailable" rather than raising. display_loop treats an unavailable sensor
+as "keep the backlight on" — a dead sensor must never leave the hangar dark.
+
+Requires the DFRobot_C4001 Python library on the Pi:
+    git clone https://github.com/DFRobot/DFRobot_C4001
+    # then put its python/raspberrypi dir on PYTHONPATH, or copy
+    # DFRobot_C4001.py next to this file.
+
+Sensor variant: SEN0610 = the 12 m "motion + ranging" C4001.
+    PRESENCE_MODE=motion   (default) → SPEED_MODE: moving targets to ~12 m,
+                                       covers the whole hangar. A motionless
+                                       person reads as "no target" — the
+                                       rolling idle timeout bridges that.
+    PRESENCE_MODE=presence            → EXIST_MODE: still+moving presence,
+                                       but only to ~8 m.
+"""
+
+import config
+
+I2C_BUS_DEFAULT  = 1
+I2C_ADDR_DEFAULT = 0x2A      # C4001 default (0x2A/0x2B); != FT6336U touch (0x38)
+MODE_DEFAULT     = "motion"  # SPEED_MODE (12 m). "presence" -> EXIST_MODE (8 m).
+
+# After this many consecutive read failures, declare the sensor dead so
+# display_loop falls back to backlight-always-on.
+_MAX_CONSEC_ERRORS = 10
+
+
+class PresenceSensor:
+    """Thin wrapper over DFRobot_C4001_I2C. `.detected()` is the only signal
+    display_loop needs; `.read_raw()` backs the --presence-test dump."""
+
+    def __init__(self, cfg=None):
+        cfg = cfg if cfg is not None else config.load_env()
+        # int(..., 0) accepts "0x2a" and "42" alike.
+        self.bus  = int(str(cfg.get("PRESENCE_I2C_BUS", I2C_BUS_DEFAULT)), 0)
+        self.addr = int(str(cfg.get("PRESENCE_I2C_ADDR", I2C_ADDR_DEFAULT)), 0)
+        self.mode = (cfg.get("PRESENCE_MODE") or MODE_DEFAULT).strip().lower()
+        self._dev = None
+        self.available = False
+        self._errors = 0
+        self._open()
+
+    def _open(self):
+        try:
+            from DFRobot_C4001 import (
+                DFRobot_C4001_I2C, SPEED_MODE, EXIST_MODE,
+            )
+        except Exception as e:  # lib not installed → feature off, screen stays on
+            print(f"presence: DFRobot_C4001 lib unavailable ({e}); "
+                  f"presence wake disabled, backlight stays on")
+            return
+        try:
+            dev = DFRobot_C4001_I2C(self.bus, self.addr)
+            if not dev.begin():
+                print(f"presence: C4001 not responding (bus {self.bus} "
+                      f"addr {hex(self.addr)})")
+                return
+            dev.set_sensor_mode(EXIST_MODE if self.mode == "presence"
+                                else SPEED_MODE)
+            self._dev = dev
+            self.available = True
+            print(f"presence: C4001 ready (mode={self.mode}, "
+                  f"addr={hex(self.addr)})")
+        except Exception as e:
+            print(f"presence: C4001 init failed: {e}")
+
+    def detected(self):
+        """True/False if a target is present, or None if the sensor is
+        unavailable (caller should fail-safe to backlight-on)."""
+        if not self.available:
+            return None
+        try:
+            det = bool(self._dev.motion_detection())
+            self._errors = 0
+            return det
+        except Exception as e:
+            self._errors += 1
+            if self._errors >= _MAX_CONSEC_ERRORS:
+                self.available = False
+                print(f"presence: C4001 read failed {self._errors}x ({e}); "
+                      f"disabling, backlight stays on")
+            return None
+
+    def read_raw(self):
+        """Diagnostic snapshot for --presence-test."""
+        if not self.available:
+            return {"available": False}
+        out = {"available": True}
+        for key, fn in (
+            ("detected", lambda: bool(self._dev.motion_detection())),
+            ("targets",  self._dev.get_target_number),
+            ("range",    self._dev.get_target_range),
+            ("speed",    self._dev.get_target_speed),
+        ):
+            try:
+                out[key] = fn()
+            except Exception as e:
+                out[key] = f"err: {e}"
+        return out


### PR DESCRIPTION
Optional motion-wake for the always-on 3.5" IPS dashboard: turn the backlight **off when the hangar's empty, on when motion is sensed** — saves LED-backlight hours + heat. Off by default; the display behaves exactly as today until `PRESENCE_ENABLED=1`.

Written now so it's ready to drop in when the **DFRobot C4001 (SEN0610, 12 m)** lands. Designed against the verified DFRobot Python API.

## What's here
- **`presence.py`** — C4001 wrapper on I²C `0x2A`, sharing the FT6336U touch bus (touch `0x38`, no clash → **zero new GPIO**). Lazy import of the vendor lib; an unavailable/failed sensor degrades to "unavailable".
- **`backlight.py`** — `gpiozero` PWM on **GPIO18** (moved off the VCC jumper). Full-off when idle with a short fade. No-op if GPIO unavailable.
- **`display_loop.py`** — the wake/sleep state machine folded into the existing poll loop:
  - **Rolling** idle timeout (default 120 s) reset by presence **or** touch → sleeps full-off, wakes instantly on motion.
  - **Tap-to-wake** swallowed: dark screen → wake only; lit screen → toggle heater as today.
  - While asleep the loop stops pushing frames and skips the fast refresh; wake renders immediately.
  - New `--presence-test` dumps detected/range/speed for 30 s (aiming/tuning), mirroring `--scan`.
- Docs: `.env.example` knobs, README setup section, CLAUDE.md component list (backfilled the missing dashboard files) + feature section.

## Fail-safe
Unwired/failed sensor, missing `DFRobot_C4001` lib, or unavailable GPIO → backlight forced **ON**. Lazy imports mean the display runs fine without any of it. **The feature can never leave the hangar screen dark.**

## Tested
- `py_compile` clean (all 3 modules).
- Dry-run `--once` still renders a 480×320 frame (existing path untouched with feature off).
- Deterministic unit test of the state machine: wake-on-presence, sleep-after-timeout, rolling-reset-on-every-detection, dead-sensor→fail-safe-on, feature-off→no-op — all pass.
- ⚠ **Not** hardware-tested — sensor arrives ~Sun May 31. `--presence-test` is the on-arrival check.

## Setup (when the sensor lands)
1. Wire C4001 to the touch I²C bus (`SDA→2, SCL→3, VCC→3.3V`); `i2cdetect -y 1` → `2a` + `38`.
2. Move the panel LED pin VCC → GPIO18. **Open hardware check:** if that pin draws >~16 mA, drive it via an N-MOSFET, not the GPIO directly.
3. `git clone https://github.com/DFRobot/DFRobot_C4001` → put `python/raspberrypi` on PYTHONPATH (or copy `DFRobot_C4001.py` beside `display_loop.py`).
4. `--presence-test` to aim → `PRESENCE_ENABLED=1` → `sudo systemctl restart display`.

Default mode is `motion` (SPEED_MODE, ~12 m, full hangar). `presence` mode (EXIST_MODE, ~8 m) holds a still person but only near-field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)