### PR TITLE
perf(stats): exclude pre-data months from the monthly batch-scan window

### DIFF
--- a/config.py
+++ b/config.py
@@ -498,6 +498,23 @@ def query_batch_stats(conn, since_epoch, until_epoch, power_on_threshold_w):
     return {row[0]: row[1:] for row in rows}
 
 
+def query_first_epoch(conn):
+    """
+    Return the epoch of the oldest reading across disk + RAM, or None if
+    there are no readings at all. Effectively free — epoch is the PRIMARY
+    KEY, so MIN(epoch) is a B-tree head lookup, not a scan.
+    """
+    if _has_ram(conn):
+        row = conn.execute(
+            "SELECT MIN(e) FROM ("
+            "SELECT MIN(epoch) AS e FROM readings"
+            " UNION ALL SELECT MIN(epoch) AS e FROM ram.readings)"
+        ).fetchone()
+    else:
+        row = conn.execute("SELECT MIN(epoch) FROM readings").fetchone()
+    return row[0] if row else None
+
+
 def _has_ram(conn):
     """Return True if 'ram' database is attached."""
     for row in conn.execute("PRAGMA database_list"):

--- a/switch.py
+++ b/switch.py
@@ -138,9 +138,11 @@ def _month_data(mk, label, ts, as_, rs, t_pct):
 # ---------------------------------------------------------------------------
 
 def _compute_months_data(conn, now_epoch=None):
-    """Build the 13-month stats list. Slow on Pi Zero W (~6s SQL scan), so the
-    main page render skips this — clients fetch it via ?monthly_stats=1 after
-    page load. Reused from both the lazy endpoint and the full-page render."""
+    """Build the 13-month stats list. Slow on Pi Zero W (~1s SQL scan over the
+    uncached months; was ~13s when pre-data months pinned the batch window), so
+    the main page render skips this — clients fetch it via ?monthly_stats=1
+    after page load. Reused from both the lazy endpoint and the full-page
+    render."""
     if now_epoch is None:
         now_epoch = int(datetime.now().timestamp())
     cur_month_date = date.today().replace(day=1)
@@ -167,6 +169,18 @@ def _compute_months_data(conn, now_epoch=None):
     }
 
     live_month_meta = [m for m in month_meta if m[5] or m[0] not in cache_map]
+    # Months that ended before the first reading can never produce rows, and
+    # never gain a cache entry either (the monthly cron only rolls the single
+    # previous month; the explicit backfill path refuses empty months) — but
+    # leaving them in the live list pins batch_start at the start of the
+    # 13-month window, making the batch query below scan the entire readings
+    # table (~13s on the Pi Zero W) instead of just the uncached recent
+    # months (~1s). An empty month *inside* the data range still widens the
+    # window the same way until it ages out of the 13-month lookback —
+    # accepted: it takes a full calendar month of downtime to create one.
+    first_epoch = config.query_first_epoch(conn)
+    if first_epoch is not None:
+        live_month_meta = [m for m in live_month_meta if m[3] > first_epoch]
     live_batch_stats = {}
     if live_month_meta:
         batch_start = min(m[2] for m in live_month_meta)
@@ -353,9 +367,9 @@ def _handle(environ):
         )
         _respond("application/json", json.dumps({"power_on": power_on, "html": body_html}))
 
-    # --- Lazy-loaded monthly stats table (~6.7s SQL scan on Pi Zero W) ---
+    # --- Lazy-loaded monthly stats table (~1s SQL scan on Pi Zero W) ---
     # Same pattern: main page skips it, client JS fetches and swaps into
-    # #monthly-stats-body. Drops main TTFB by ~6s.
+    # #monthly-stats-body, keeping the scan off the main TTFB.
     if qs.get("monthly_stats") == "1":
         conn = config.get_db()
         try:
@@ -665,7 +679,7 @@ def _handle(environ):
                 door_ranges = aggregate.detect_door_events(pairs)
 
         # Monthly stats are lazy-loaded by client JS via ?monthly_stats=1.
-        # Computing them inline adds ~6.7s on a Pi Zero W (full SQL scan over
+        # Computing them inline adds ~1s on a Pi Zero W (SQL scan over the
         # current month's readings + cache lookups). Skipping here drops TTFB.
 
         conn.close()


### PR DESCRIPTION
## Problem

`?monthly_stats=1` took **13.4s** server-side (measured via curl on the Pi) even after backfilling the 2026-02 cache entry. The 13-month table starts at 2025-06 but logging began 2026-02-26; the eight pre-data months can never gain `monthly_cache` rows (the monthly cron only rolls the previous month, and the explicit backfill path refuses empty months), so they always counted as "live" months. `_compute_months_data` computes all live months with one contiguous SQL window `[min(start), max(end)]` — so `batch_start` stayed pinned at 2025-06-01 and every load scanned the **entire readings table** (~140k rows, per-row `strftime` + UNION dedup on a Pi Zero W), discarding the re-aggregated cached months at render time.

## Fix

New `config.query_first_epoch()` (MIN(epoch) over disk+RAM — B-tree head lookup on the PK in both DBs) and a filter in `_compute_months_data` dropping live months that ended before the first reading. With 2026-02..05 cached, the window collapses to the current month: **13.4s → ~1.2s** (timed the exact query both ways on the Pi).

Gap months *with* data but no cache row still compute live (and still widen the window until backfilled via `log_temp.py rollup YYYY-MM` — that's the correct behavior, now noted in a comment). Also refreshes three stale ~6/6.7s timing comments in `switch.py`.

## Verification

- Local 4-case test replicating prod state (disk+RAM DBs, cache rows, spy on `query_batch_stats`): window collapses to current month; uncached-gap-month-with-data stays live; empty DB no-crash; no-RAM path works.
- Adversarial 3-lens review (correctness / fixes-the-problem / conventions): all verdicts "ship". Independently reproduced the window collapse, confirmed `MIN(epoch)` is a SEARCH (not SCAN) via EXPLAIN QUERY PLAN on both schemas, and confirmed no other full-table scan remains in the endpoint path.
- CDN pins checked: all current.
- Docs reviewed: project CLAUDE.md / README don't reference the stale timings — no changes needed.

Deploy note: `switch.py` changed, so `git pull` alone triggers the mod_wsgi reload (covers the `config.py` change too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)