### PR TITLE
perf(render): main page 2.4s -> ~0.45s on the Pi Zero W

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ The original BCD-vs-BINARY format question on `ac_total_kwh` is **resolved**, bu
 - `LOCATION` in `.env` can be an ICAO code (e.g. `KLMO`); lat/lon resolved via OurAirports CSV geocoding on first run.
 - mod_wsgi daemon mode auto-reloads when **`switch.py`** changes. `git pull` is sufficient if the change is in `switch.py` itself; for changes to imported modules (`aggregate.py`, `hvac.py`, `config.py`), `git pull` updates the file on disk but mod_wsgi keeps the previously-imported module in memory until `switch.py`'s mtime changes. So after pulling a non-`switch.py` change, also do `touch switch.py` to force a daemon reload. (Symptom of forgetting: deployed code looks right on disk but the WSGI app behaves like it did before the pull. Verified 2026-05-08 with PR #19's `aggregate.py` threshold change.)
 - All schema additions use `ALTER TABLE ... ADD COLUMN` wrapped in try/except in `get_db()` / `get_ram_db()`. Don't introduce a separate migration system.
+- **Main-page TTFB budget (~0.5s on the Pi Zero W, fixed 2026-06-12 from 2.4s).** The temperature display reads the latest cron-logged row (`config.read_temp_cached`, falls back to a live probe read if logging stalls >5 min) — a live DS18B20 conversion blocks ~850ms, so don't put `read_temp()` back on the render path. Anything else slow belongs behind a lazy fragment endpoint (see "URL surface"), the established pattern for monthly stats, HVAC card, and door events.
 
 ## WiFi bridge (`scripts/setup-wifi-bridge.sh`)
 - **Purpose: pairing only.** The Midea dongle's pairing app (NetHome Plus) refuses to pair against an open SSID. Many hangar WiFi networks are open. The bridge lets the Pi broadcast its own WPA2 SSID for the dongle to live on, while the Pi stays a client on the open hangar WiFi and NATs the dongle's traffic out.
@@ -205,13 +206,14 @@ The wrappers were verified against msmart-ng 2025.12.0. If you upgrade, watch th
 - HVAC immediate apply: `?hvac_apply=1` plus `&hvac_power=0|1&hvac_mode=…&hvac_target_f=…&hvac_fan_speed=…`. Special case: `&hvac_mode=freeze` triggers the Freeze Prevention preset and ignores the other args.
 - Schedule add: `?sched_dt=YYYY-MM-DDTHH:MM&sched_device=heater|hvac` plus device-specific params (`sched_action` for heater; `sched_hvac_mode/target_f/fan_speed/power` for HVAC).
 - Schedule cancel: `?cancel_id=<created_epoch>`.
-- Chart range: `?range=7d|30d|YYYY-MM`.
+- Chart range: `?range=1d|7d|30d|YYYY-MM`.
+- Lazy fragments (fetched by page JS after load, kept off the main TTFB): `?monthly_stats=1` (~1s SQL scan), `?hvac_state=1` (dongle round-trip), `?door_events=1&range=1d|7d` (~0.6s raw-row scan).
 
 ## Chart bands, lines, and colors
 - Heater band (engine-block) — `rgba(220, 53, 69, 0.25)` red
 - Fan band — `rgba(13, 110, 253, 0.20)` blue
 - Cold annotation (≤48°F) — `rgba(255, 152, 0, 0.15)` orange box
-- Door-open marker — `rgba(219, 39, 119, 0.55)` fuchsia bar (distinct from the orange cold annotation); computed by `aggregate.detect_door_events()` from raw per-minute rows (1d/7d only — 30d/monthly skipped because events would render as overlapping pixels). Tooltip shows `Door event (cold air in / warm air in, N°F peak)`.
+- Door-open marker — `rgba(219, 39, 119, 0.55)` fuchsia bar (distinct from the orange cold annotation); computed by `aggregate.detect_door_events()` from raw per-minute rows (1d/7d only — 30d/monthly skipped because events would render as overlapping pixels). Lazy-loaded via `?door_events=1` and painted in after the chart renders — the 10k-row fetch costs ~0.6s on the Pi Zero W, so it's off the main TTFB (SQL window functions were measured *slower* than the Python scan on this CPU; don't re-try that). Tooltip shows `Door event (cold air in / warm air in, N°F peak)`.
 - Hangar temp line — `rgb(75, 192, 192)` teal (left y-axis, °F)
 - Ambient line — `rgb(34, 197, 94)` green (left y-axis, °F)
 - HVAC power line — `rgb(168, 85, 247)` purple (**right y-axis, Watts**)

--- a/config.py
+++ b/config.py
@@ -196,6 +196,31 @@ def read_temp():
     return None
 
 
+def read_temp_cached(conn, max_age_secs=300):
+    """
+    Return the latest logged temp_c (float) from the readings DBs, falling
+    back to a live probe read when the log is stale or empty.
+
+    A live read_temp() blocks ~850ms — the w1_slave read triggers a fresh
+    DS18B20 conversion — and the cron job already logs the same probe every
+    minute, so the newest readings row is normally <=60s old. Serving that
+    keeps the page render fast; the fallback keeps the temperature display
+    alive (just slow) if cron logging ever stalls.
+    """
+    one = ("SELECT epoch, temp_c FROM {} WHERE temp_c IS NOT NULL"
+           " ORDER BY epoch DESC LIMIT 1")
+    if _has_ram(conn):
+        sql = (f"SELECT epoch, temp_c FROM ({one.format('readings')})"
+               f" UNION ALL SELECT epoch, temp_c FROM ({one.format('ram.readings')})"
+               " ORDER BY epoch DESC LIMIT 1")
+    else:
+        sql = one.format("readings")
+    row = conn.execute(sql).fetchone()
+    if row and datetime.now().timestamp() - row[0] <= max_age_secs:
+        return row[1]
+    return read_temp()
+
+
 # ---------------------------------------------------------------------------
 # Ambient temperature (Open-Meteo, 15-min file cache)
 # ---------------------------------------------------------------------------
@@ -426,11 +451,15 @@ def query_bucketed(conn, since_epoch, until_epoch, bucket_secs=900):
     inner_cols = "epoch, temp_c, heater_state, ambient_c, fan_state, ac_power_w"
     group = f"GROUP BY (epoch/{bs})*{bs} ORDER BY (epoch/{bs})*{bs}"
     if _has_ram(conn):
+        # UNION ALL, not UNION: disk and RAM never hold the same epoch (the
+        # weekly flush copies + deletes in one transaction), and UNION's
+        # dedupe sort over the raw rows doubles this query's time on a Pi
+        # Zero W (350ms -> 190ms for the 7d chart, measured 2026-06-12).
         sql = (
             f"SELECT {select} FROM ("
             f"SELECT {inner_cols} FROM readings"
             " WHERE epoch >= ? AND epoch < ?"
-            " UNION"
+            " UNION ALL"
             f" SELECT {inner_cols} FROM ram.readings"
             " WHERE epoch >= ? AND epoch < ?"
             f") {group}"

--- a/switch.py
+++ b/switch.py
@@ -367,6 +367,26 @@ def _handle(environ):
         )
         _respond("application/json", json.dumps({"power_on": power_on, "html": body_html}))
 
+    # --- Lazy-loaded door events (~0.6s on Pi Zero W) ---
+    # Detection needs raw per-minute rows (10k for 7d) pulled into Python;
+    # that fetch alone costs ~300ms on this hardware, so the main page render
+    # skips it and client JS fetches this, then repaints the chart's fuchsia
+    # door bars. Only the 1d/7d ranges detect door events (30d/monthly would
+    # render them as overlapping pixels).
+    if qs.get("door_events") == "1":
+        door_range = qs.get("range", "7d")
+        door_ranges = []
+        if door_range in ("1d", "7d"):
+            de_now = int(datetime.now().timestamp())
+            de_cutoff = de_now - (86400 if door_range == "1d" else 7 * 86400)
+            conn = config.get_db()
+            try:
+                pairs = config.query_temp_pairs(conn, de_cutoff, de_now)
+            finally:
+                conn.close()
+            door_ranges = aggregate.detect_door_events(pairs)
+        _respond("application/json", json.dumps(door_ranges))
+
     # --- Lazy-loaded monthly stats table (~1s SQL scan on Pi Zero W) ---
     # Same pattern: main page skips it, client JS fetches and swaps into
     # #monthly-stats-body, keeping the scan off the main TTFB.
@@ -514,6 +534,10 @@ def _handle(environ):
     # -----------------------------------------------------------------------
     enable_temp = config.ENABLE_TEMP
 
+    # One connection for the whole render (temp display, schedules, chart) \u2014
+    # get_db()'s schema bootstrap costs ~10ms per open on the Pi Zero W.
+    conn = config.get_db()
+
     # --- Heater state ---
     heater_on = config.read_gpio() == "1"
     status = "on" if heater_on else "off"
@@ -525,9 +549,11 @@ def _handle(environ):
     )
 
     # --- Temperature display ---
+    # Latest cron-logged reading (<=60s old) instead of a live probe read \u2014
+    # a fresh DS18B20 conversion blocks for ~850ms on every page load.
     temp_display = ""
     if enable_temp:
-        temp_c = config.read_temp()
+        temp_c = config.read_temp_cached(conn)
         if temp_c is None:
             temp_display = "Temperature probe not found"
         else:
@@ -566,13 +592,11 @@ def _handle(environ):
     hvac_configured = hvac.is_configured()
 
     # --- Pending schedules ---
-    conn = config.get_db()
     pending_rows = conn.execute(
         "SELECT created_epoch, execute_epoch, action, "
         "COALESCE(device, 'heater'), COALESCE(params, '') "
         "FROM schedules ORDER BY execute_epoch"
     ).fetchall()
-    conn.close()
 
     pending_sched_rows = []
     for created_epoch, execute_epoch, action, device, params in pending_rows:
@@ -638,8 +662,6 @@ def _handle(environ):
     months_data = []
 
     if enable_temp:
-        conn = config.get_db()
-
         # Determine whether to use cached chart data
         chart_from_cache = False
         if _is_valid_month(range_param) and range_param != cur_month_date.strftime("%Y-%m"):
@@ -668,21 +690,13 @@ def _handle(environ):
             ambient_data = live_result["ambient_data"]
             power_data = live_result.get("power_data", [])
 
-            # Door-event detection runs only on the 1d / 7d ranges. It
-            # needs raw per-minute (temp_c, ac_indoor_f) pairs — bucketed
-            # averages would smooth out the 5-15min divergence signal —
-            # so the row count is unbounded by bucket_secs. 7d × 1440 =
-            # ~10k rows is fine on the Pi Zero W; 30d at 43k pushes it
-            # and the events would render as overlapping pixels anyway.
-            if range_param in ("1d", "7d"):
-                pairs = config.query_temp_pairs(conn, chart_cutoff, chart_end_epoch)
-                door_ranges = aggregate.detect_door_events(pairs)
+        # Door events (1d/7d only) are lazy-loaded by client JS via
+        # ?door_events=1 — detection needs ~10k raw per-minute rows pulled
+        # into Python (~0.6s on a Pi Zero W), so it's kept off the main TTFB
+        # like the monthly stats (?monthly_stats=1, ~1s SQL scan) and the
+        # HVAC card (?hvac_state=1, dongle round-trip).
 
-        # Monthly stats are lazy-loaded by client JS via ?monthly_stats=1.
-        # Computing them inline adds ~1s on a Pi Zero W (SQL scan over the
-        # current month's readings + cache lookups). Skipping here drops TTFB.
-
-        conn.close()
+    conn.close()
 
     # --- Render template ---
     template = _get_jinja_env().get_template("index.html")

--- a/templates/index.html
+++ b/templates/index.html
@@ -521,6 +521,17 @@ if (data.length > 0) {
   document.getElementById('tempChart').style.display = 'none';
   document.getElementById('noChartData').style.display = 'block';
 }
+{% if range in ("1d", "7d") %}
+// Door events are lazy-loaded (detection scans ~10k raw rows server-side,
+// ~0.6s on the Pi) — the chart renders immediately and the fuchsia bars
+// are painted in once this arrives. doorRanges is the same closure var the
+// doorBand plugin and the tooltip read, so a repaint is all that's needed.
+fetch('switch.py?door_events=1&range={{ range }}').then(function(r){return r.json()}).then(function(d) {
+  if (!d.length || !tempChart) return;
+  doorRanges = d;
+  tempChart.update('none');
+}).catch(function(){});
+{% endif %}
 });
 </script>
 {% endif %}


### PR DESCRIPTION
## Problem
Main-page TTFB was ~2.4s server-side on the Pi Zero W (monthly stats and HVAC card were already lazy — this is the bare render path).

## Profile (measured on the Pi, deployed code, warm in-process `_handle` = 2135ms)

| Component | ms | Fix |
|---|---|---|
| `read_temp()` live DS18B20 read | 854 | serve latest cron-logged row (`read_temp_cached`, 1.4ms); live-probe fallback if logging stalls >5 min |
| door events (10k-row fetch + Python scan) | 620 | lazy `?door_events=1` endpoint, same pattern as `?monthly_stats=1` / `?hvac_state=1`; chart paints the fuchsia bars when it lands |
| `query_bucketed` 7d | 344 | `UNION` → `UNION ALL` (190ms; disk/RAM epochs disjoint — flush copies+deletes atomically; identical output verified) |
| 2× `get_db()` schema bootstrap | ~20 | one conn per render |
| compute_bucketed + Jinja + misc | ~300 | left alone |

Dead end, documented in CLAUDE.md so it isn't re-tried: SQL window functions (`LAG() OVER`) for door flagging measured **slower** than the Python scan on this CPU (824ms vs 620ms).

## Door events: behavior unchanged
`detect_door_events()` itself is untouched — only *where* it runs moves. Endpoint output verified identical to the old inline path on live data (same single 7d event, same xMin/xMax/peak/direction). 1d works; 30d/monthly return `[]` (unchanged: never detected there).

## Before/after (on the Pi)
Before, production Apache: `curl` → **2.418s** (76008B).
A/B through identical wsgiref harnesses (deploy dir vs branch checkout, interleaved, warm, 6 runs each):
- old: 2.21 / 2.38 / 2.45 / 2.21 / 3.23 / 2.61 s
- new: **0.94 / 0.43 / 0.41 / 0.64 / 0.42 / 0.41 s** (outliers = per-minute cron tick sharing the single core)

`?door_events=1&range=7d` (async, off TTFB): ~0.7–0.8s.

## Notes
- Temp display is now ≤60s stale (cron-logged) instead of live — immaterial for a hangar thermometer, and it's the same probe.
- Deploy: plain `git pull` — `switch.py` mtime changes, so mod_wsgi reloads itself (covers the `config.py` change too).
- ⚠ browser check after deploy: fuchsia door bars + their tooltip pop in on 7d/1d a moment after the chart renders.
- Docs reviewed: CLAUDE.md updated (TTFB budget, lazy-fragment list, door lazy-load); README/PLAN untouched (internal-only change).
- `scripts/check-cdn-versions.sh`: all pins current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)