### PR TITLE
fix(chart): load Hammer.js so drag-to-pan (and pinch) actually work

### DIFF
--- a/scripts/check-cdn-versions.sh
+++ b/scripts/check-cdn-versions.sh
@@ -12,6 +12,7 @@ pkgs=(
   chart.js
   chartjs-adapter-date-fns
   chartjs-plugin-zoom
+  hammerjs
 )
 
 stale=0

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,9 @@
 {% if enable_temp %}
 <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0" integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws" crossorigin="anonymous"></script>
+<!-- Hammer.js is a required peer dep of chartjs-plugin-zoom for PAN + pinch gestures
+     (wheel-zoom works without it). Must load before the zoom plugin. -->
+<script defer src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8" integrity="sha384-Cs3dgUx6+jDxxuqHvVH8Onpyj2LF1gKZurLDlhqzuJmUqVYMJ0THTWpxK5Z086Zm" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.2.0" integrity="sha384-dwwI6ICEN/0ZQlS5owhUa/6ZzvwUPmjH45bFVCAcjgjTulbHJvlE+TGU3g1k0N3R" crossorigin="anonymous"></script>
 {% endif %}
 </head>


### PR DESCRIPTION
## Bug
On the temperature chart you can wheel-zoom in, but you can't **drag to pan** left/right to reposition the zoomed window. Reported on desktop; also affects pinch on touch.

## Root cause
`chartjs-plugin-zoom` requires **Hammer.js** as a peer dependency for *pan and pinch* gestures. Wheel-zoom uses native DOM events so it works standalone — but `pan: { enabled: true }` is completely **inert** without Hammer. The template loaded chart.js + the date adapter + the zoom plugin, but **never Hammer**, so the pan config did nothing.

The pan was never broken in *config* — it's been `pan: { enabled: true, mode: 'x' }` since the Python rewrite. The gesture-recognition layer just wasn't there.

## Fix
Add `hammerjs@2.0.8` (bare jsdelivr URL, pinned + SRI + `defer`) **before** the zoom plugin script. Chart init runs on `DOMContentLoaded` (after all deferred scripts), so Hammer is present at chart creation.

## How verified
Headless-browser repro with the exact CDN pins + zoom/pan config:
- **Diagnosis:** `window.Hammer === undefined`; programmatic `chart.pan({x:200})` moved the range *exactly* proportionally (pan machinery fine), but a synthetic drag panned **0 ms** → gesture layer dead.
- **After adding Hammer:** `Hammer` is a function; the same drag pans ~39% of the visible span; wheel-zoom unchanged; no console/SRI errors with `integrity` set.

Also added `hammerjs` to `scripts/check-cdn-versions.sh` (reports `2.0.8 (current)`).

No app version surface, no server changes — template + CDN only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)