### PR TITLE
fix(chart): dismiss lingering tooltip on tap-away (mobile)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -520,6 +520,25 @@ if (data.length > 0) {
   var resetBtn = document.getElementById('resetZoom');
   resetBtn.style.display = '';
   resetBtn.addEventListener('click', function() { tempChart.resetZoom(); });
+
+  // Touch shows a tooltip on tap but never clears it (no mouseout on touch),
+  // so it lingers. Dismiss when the tap lands outside the plotting area —
+  // the chart margins or off the canvas entirely; taps on a data region still
+  // inspect/move the tooltip as before.
+  document.addEventListener('pointerdown', function(e) {
+    if (!tempChart) return;
+    var insidePlot = false;
+    if (e.target === tempChart.canvas) {
+      var r = tempChart.canvas.getBoundingClientRect(), ca = tempChart.chartArea;
+      var x = e.clientX - r.left, y = e.clientY - r.top;
+      insidePlot = x >= ca.left && x <= ca.right && y >= ca.top && y <= ca.bottom;
+    }
+    if (!insidePlot) {
+      tempChart.setActiveElements([]);
+      if (tempChart.tooltip) tempChart.tooltip.setActiveElements([], { x: 0, y: 0 });
+      tempChart.update('none');
+    }
+  });
 } else {
   document.getElementById('tempChart').style.display = 'none';
   document.getElementById('noChartData').style.display = 'block';


### PR DESCRIPTION
## Bug
On mobile, tapping the chart shows a tooltip, but it never goes away — tapping elsewhere doesn't dismiss it. (Touch has no `mouseout`, so Chart.js never clears the active tooltip.)

## Fix
A `document` `pointerdown` handler dismisses the tooltip when the tap lands **outside the plotting area** — the chart's axis-label margins or off the canvas entirely. Taps on a data region still inspect/move the tooltip as before.

- Uses `chartArea` + `getBoundingClientRect` to tell "data region" from "margin"; coordinates are in the same CSS-pixel space for responsive charts.
- Desktop unaffected: `mouseout` already clears, and an off-canvas click just harmlessly clears any lingering tip.
- No interference with pan: a pan starts inside the plot area, where the handler skips dismissal.

## How verified
Headless-browser repro with the same interaction/tooltip config + this exact handler:
- tooltip active after show (`1`)
- tap on an off-chart button → cleared (`0`)
- tap in the canvas axis-label margin → cleared (`0`)
- tap inside the plot area → left intact (`1`)

No console errors. Template-only change → Jinja auto-reload picks it up on `git pull` (no `touch switch.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)