### PR TITLE
fix(chart): draw temp lines in front of shaded fills

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -381,13 +381,20 @@ if (data.length > 0) {
   var tempChart = new Chart(document.getElementById('tempChart'), {
     type: 'line',
     data: {
+      // Layering convention: SHADED datasets (anything with a fill — the
+      // Hangar area + the Heater/Fan bands) get `order: 1` so they render
+      // BEHIND; LINE datasets (Ambient, HVAC W) stay at the default `order: 0`
+      // so they render IN FRONT. Chart.js draws lowest-`order` last (on top),
+      // so a fill can never paint over a line. Any new line dataset added with
+      // no `order` is automatically safe; give new filled datasets `order: 1`.
       datasets: [{
         data: data,
         borderColor: 'rgb(75, 192, 192)',
         backgroundColor: 'rgba(75, 192, 192, 0.2)',
         fill: true,
         pointRadius: 0,
-        tension: 0.3
+        tension: 0.3,
+        order: 1
       }, {
         data: heaterData,
         borderColor: 'transparent',
@@ -395,7 +402,8 @@ if (data.length > 0) {
         fill: 'origin',
         pointRadius: 0,
         tension: 0.3,
-        spanGaps: false
+        spanGaps: false,
+        order: 1
       }, {
         data: fanData,
         borderColor: 'transparent',
@@ -403,7 +411,8 @@ if (data.length > 0) {
         fill: 'origin',
         pointRadius: 0,
         tension: 0.3,
-        spanGaps: false
+        spanGaps: false,
+        order: 1
       }, {
         // Ambient is sparse when the upstream weather API fails — align
         // it to the temp x-array (nulls where ambient is missing) so the
@@ -419,6 +428,7 @@ if (data.length > 0) {
         tension: 0.4,
         cubicInterpolationMode: 'monotone',
         spanGaps: 600000
+        // order omitted → default 0 → drawn in front of the shaded datasets.
       }, {
         // HVAC compressor power draw — bound to the right Watts axis (y1).
         // Only buckets above the standby threshold (>100W) are present;


### PR DESCRIPTION
## What

The **Ambient** (outdoor temp) line was invisible on the 7-day chart — hidden behind the Hangar dataset's teal shaded area in the 70–80 °F band where outdoor and hangar temps overlap.

## Why

Chart.js draws the lowest-`order` dataset *last* (i.e. on top). With every dataset at the default `order: 0`, ties break by array index, so the Hangar dataset (index 0) rendered on top — and because it has `fill: true`, its semi-transparent fill painted over the Ambient line sitting behind it.

## Fix

Rather than a one-off z-bump on Ambient, establish a layering **convention** so this can't recur:

- **Shaded/filled** datasets (Hangar area, Heater band, Fan band) → `order: 1` → drawn behind.
- **Line** datasets (Ambient, HVAC W) → default `order: 0` → drawn in front.

Resulting back-to-front order: `Fan band → Heater band → Hangar fill+line → HVAC line → Ambient line`. The HVAC W line was technically clipped by the fill too and is now also reliably in front.

## Reviewer notes

- Hangar fill still sits over the Heater/Fan bands exactly as before (tie broken by array index within the `order: 1` group) — nothing else in the chart shifts.
- `order` only affects draw/stack order; `datasetIndex` is unchanged, so the tooltip label/color callbacks (which key off `item.datasetIndex`) are unaffected.
- Any future **line** dataset added with no `order` is safe by default; the convention is documented inline above the `datasets` array.
- Template-only change — mod_wsgi serves `templates/index.html` directly, so deploy is a plain `git pull` on the Pi (no `touch switch.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)