### PR TITLE
feat(scheduler): add exhaust fan on/off/auto scheduling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ Files:
 
 When adding a new persistent thing, ask: how often is it written? If more than weekly → `/run`. If user-action-driven and rare → SD card is fine.
 
-## Schedule schema (extended for HVAC)
+## Schedule schema (extended for HVAC + fan)
 The `schedules` table has two columns added on top of the original heater schema:
-- `device TEXT DEFAULT 'heater'` — `'heater'` or `'hvac'`
+- `device TEXT DEFAULT 'heater'` — `'heater'`, `'fan'`, or `'hvac'`
 - `params TEXT DEFAULT ''` — JSON for HVAC schedules: `{power, mode, target_f, fan_speed}` or `{mode: "freeze"}`
-Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set"` and read everything from `params`. `log_temp.py do_log()` dispatches by device.
+Existing heater rows keep `action` = `"0"`/`"1"`; HVAC rows use `action` = `"set"` and read everything from `params`. **Fan rows store the target fan *mode* in `action` (`"on"`/`"off"`/`"auto"`), not a GPIO level** — the fan is mode-driven and the per-minute cron re-enforces the mode every tick, so a fan schedule must set the mode. `do_log()` sets it via `config.write_fan_mode()` inside the due-schedule loop, which runs *before* the fan auto-logic block, so the GPIO is applied that same tick (and `"auto"` correctly hands control back to the temp-threshold logic). `log_temp.py do_log()` dispatches by device.
 
 ## Readings columns added for HVAC
 - `readings.ac_state INTEGER` — 0=off, 1=heat, 2=cool, 3=fan, 4=dry, 5=auto. The unit's *mode*, not its *running state*. In Freeze Prevention overnight the unit sits in HEAT mode 24/7 even though the compressor cycles only briefly per hour, so this column alone overstates "HVAC on".
@@ -219,7 +219,7 @@ The wrappers were verified against msmart-ng 2025.12.0. If you upgrade, watch th
 - Heater: `?state=0|1`
 - Fan: `?fan_state=0|1`, `?fan_mode=auto`
 - HVAC immediate apply: `?hvac_apply=1` plus `&hvac_power=0|1&hvac_mode=…&hvac_target_f=…&hvac_fan_speed=…&hvac_turbo=0|1`. Special case: `&hvac_mode=freeze` triggers the Freeze Prevention preset and ignores the other args (turbo included). `hvac_turbo` is the Apply form's Turbo checkbox; an unchecked box submits nothing, so absent → off.
-- Schedule add: `?sched_dt=YYYY-MM-DDTHH:MM&sched_device=heater|hvac` plus device-specific params (`sched_action` for heater; `sched_hvac_mode/target_f/fan_speed/power` for HVAC).
+- Schedule add: `?sched_dt=YYYY-MM-DDTHH:MM&sched_device=heater|fan|hvac` plus device-specific params (`sched_action=0|1` for heater; `sched_fan_action=on|off|auto` for the fan; `sched_hvac_mode/target_f/fan_speed/power` for HVAC).
 - Schedule cancel: `?cancel_id=<created_epoch>`.
 - Chart range: `?range=1d|7d|30d|YYYY-MM`.
 - Lazy fragments (fetched by page JS after load, kept off the main TTFB): `?monthly_stats=1` (~1s SQL scan), `?hvac_state=1` (dongle round-trip), `?door_events=1&range=1d|7d` (~0.6s raw-row scan).

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ Requires [`msmtp`](https://marlam.de/msmtp/) to be installed and configured. The
 
 ## Scheduling
 
-The web UI includes a one-shot scheduler that can act on either the engine-block heater (turn on/off) or the hangar HVAC (mode + target temp + fan, including a one-click Freeze Prevention preset). Schedules are stored in the database and executed by the every-minute cron job — no additional setup needed. Schedules survive reboots.
+The web UI includes a one-shot scheduler that can act on the engine-block heater (turn on/off), the exhaust fan (turn on, turn off, or set back to auto), or the hangar HVAC (mode + target temp + fan, including a one-click Freeze Prevention preset). Schedules are stored in the database and executed by the every-minute cron job — no additional setup needed. Schedules survive reboots.
+
+Fan schedules set the fan's *mode* rather than pulsing the relay, so "Turn ON" holds the fan on until another schedule or manual action changes it; "Set to Auto" hands control back to the temperature-threshold auto logic (handy for "force off overnight, back to auto in the morning").
 
 ---
 

--- a/log_temp.py
+++ b/log_temp.py
@@ -254,6 +254,15 @@ def do_log():
                     )
                 except Exception:
                     pass
+            elif device == "fan":
+                # Exhaust fan: action is a fan mode ('on'/'off'/'auto'). Set the
+                # mode only — the fan auto-logic block below applies the GPIO
+                # this same tick, and the per-minute cron re-enforces it after.
+                if action in ("on", "off", "auto"):
+                    try:
+                        config.write_fan_mode(action)
+                    except OSError:
+                        pass
 
             conn.execute(
                 "DELETE FROM schedules WHERE created_epoch = ?",

--- a/switch.py
+++ b/switch.py
@@ -31,6 +31,11 @@ try:
 except ImportError:
     Markup = str  # type: ignore[assignment,misc]  # fallback for dev environments without jinja2
 
+# Fan schedules store one of these in schedules.action; log_temp.py executes
+# them by setting the fan *mode* (config.write_fan_mode) — not a raw GPIO write,
+# because the per-minute cron re-enforces the mode every tick.
+_FAN_SCHED_LABELS = {"on": "Turn ON", "off": "Turn OFF", "auto": "Set to Auto"}
+
 # Module-level Jinja2 environment — created once per process, reused on every request.
 _jinja_env = None
 
@@ -487,10 +492,15 @@ def _handle(environ):
     now_epoch = int(datetime.now().timestamp())
     sched_msg = Markup("")
 
-    sched_dt_raw  = qs.get("sched_dt", "")
-    sched_device  = qs.get("sched_device", "heater")
-    sched_action  = qs.get("sched_action", "")
-    if sched_dt_raw and (sched_device == "hvac" or sched_action in ("0", "1")):
+    sched_dt_raw     = qs.get("sched_dt", "")
+    sched_device     = qs.get("sched_device", "heater")
+    sched_action     = qs.get("sched_action", "")
+    sched_fan_action = qs.get("sched_fan_action", "")
+    if sched_dt_raw and (
+        sched_device == "hvac"
+        or (sched_device == "fan" and sched_fan_action in _FAN_SCHED_LABELS)
+        or (sched_device == "heater" and sched_action in ("0", "1"))
+    ):
         sched_dt_decoded = urllib.parse.unquote_plus(sched_dt_raw)
         try:
             sched_epoch = int(
@@ -538,6 +548,18 @@ def _handle(environ):
                     conn.commit()
                     conn.close()
                     _home_redirect(environ)
+            elif sched_device == "fan":
+                # Exhaust fan: action is a fan mode ('on'/'off'/'auto').
+                conn = config.get_db()
+                conn.execute(
+                    "INSERT OR REPLACE INTO schedules "
+                    "(created_epoch, execute_epoch, action, device, params) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (now_epoch, sched_epoch, sched_fan_action, "fan", ""),
+                )
+                conn.commit()
+                conn.close()
+                _home_redirect(environ)
             else:
                 conn = config.get_db()
                 conn.execute(
@@ -639,6 +661,9 @@ def _handle(environ):
         if device == "hvac":
             action_label = _hvac_sched_label(params)
             badge = '<span class="badge bg-info text-dark me-1">HVAC</span>'
+        elif device == "fan":
+            action_label = _FAN_SCHED_LABELS.get(action, action)
+            badge = '<span class="badge bg-primary me-1">Fan</span>'
         else:
             action_label = "Turn ON" if action == "1" else "Turn OFF"
             badge = '<span class="badge bg-secondary me-1">Heater</span>'

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,6 +92,7 @@
     <label for="sched_device" class="form-label mb-0 small">Device</label>
     <select id="sched_device" name="sched_device" class="form-select form-select-sm" onchange="schedToggle()">
       <option value="heater">Heater</option>
+      <option value="fan">Fan</option>
       {% if hvac_configured %}<option value="hvac">HVAC</option>{% endif %}
     </select>
   </div>
@@ -100,6 +101,14 @@
     <select id="sched_action" name="sched_action" class="form-select form-select-sm">
       <option value="1">Turn ON</option>
       <option value="0">Turn OFF</option>
+    </select>
+  </div>
+  <div class="col-auto sched-fan" style="display:none">
+    <label for="sched_fan_action" class="form-label mb-0 small">Action</label>
+    <select id="sched_fan_action" name="sched_fan_action" class="form-select form-select-sm">
+      <option value="on">Turn ON</option>
+      <option value="off">Turn OFF</option>
+      <option value="auto">Set to Auto</option>
     </select>
   </div>
   {% if hvac_configured %}
@@ -138,6 +147,7 @@
 function schedToggle() {
   var device = document.getElementById('sched_device').value;
   document.querySelectorAll('.sched-heater').forEach(function(el) { el.style.display = device === 'heater' ? '' : 'none'; });
+  document.querySelectorAll('.sched-fan').forEach(function(el) { el.style.display = device === 'fan' ? '' : 'none'; });
   document.querySelectorAll('.sched-hvac').forEach(function(el) { el.style.display = device === 'hvac' ? '' : 'none'; });
   if (device === 'hvac') schedHvacModeToggle();
 }


### PR DESCRIPTION
## Summary

The one-shot scheduler could only drive the **heater** and **HVAC**. This adds the **exhaust fan** as a third schedulable device, mirroring the fan card's three actions: **Turn ON**, **Turn OFF**, **Set to Auto**.

The fan is mode-driven (`auto`/`on`/`off`) — the per-minute cron re-enforces the mode every tick — so a fan schedule stores the target **mode** in `schedules.action` (not a GPIO level) and `log_temp.do_log()` executes it via `config.write_fan_mode()`. That write lands inside the due-schedule loop, which runs immediately **before** the fan auto-logic block, so the GPIO is applied in the same tick (and `"auto"` correctly hands control back to the temp-threshold logic).

### Why "Set to Auto" as a third option
On/off alone would trap the fan out of auto until someone manually clicks "Set to Auto" on the card (e.g. you couldn't schedule "force off overnight, back to auto in the morning"). Adding auto — which the fan card already exposes — makes it complete for one extra `<option>`.

## Changes
- **switch.py** — `sched_fan_action` param + validation, `device='fan'` insert branch, `_FAN_SCHED_LABELS`, Fan badge (`bg-primary`) in the pending-schedules list
- **log_temp.py** — `device == 'fan'` dispatch → `config.write_fan_mode(action)`
- **templates/index.html** — Fan device `<option>`, action dropdown (ON/OFF/Auto), `schedToggle()` show/hide wiring
- **CLAUDE.md / README.md** — schedule schema, URL surface, and Scheduling section

## URL surface
`?sched_dt=YYYY-MM-DDTHH:MM&sched_device=fan&sched_fan_action=on|off|auto`

## Test plan
Both tests run off-Pi with GPIO/sensors/network stubbed.

- [x] **Execution path** — real `do_log()` against a temp DB:
  - `on` → mode `on` + GPIO high + schedule row consumed + `fan_state=1` logged
  - `off` → mode `off` + GPIO low + `fan_state=0` logged
  - `auto` (hangar 10 °C, below 26.67 °C threshold) → GPIO stays off
  - `auto` (hangar 30 °C, ambient 20 °C) → auto turns GPIO on
- [x] **Template render** — Jinja render across HVAC configured/not × pending rows present/absent: Fan option, `sched_fan_action` select, "Set to Auto" option, `sched-fan` toggle class, and JS toggle all present; pending Fan row renders
- [x] `python3 -m py_compile switch.py log_temp.py config.py`
- [ ] **On the Pi** (post-deploy): schedule a fan action a couple minutes out, confirm the pending list shows the **Fan** badge + label, and that the fan mode/relay flips at execute time

## Notes
- Timing: a scheduled fan action applies within the cron tick that fires it (≤60s granularity — same as existing heater/HVAC schedules). The card's manual toggle stays instant (writes GPIO directly).
- Cancel is device-agnostic (`?cancel_id=<created_epoch>`), so fan schedules cancel like the others — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)